### PR TITLE
Set package-mode = false in the root pyproject.toml because it is a monorepo.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ name = "kitsuyui-pypi-playground"
 version = "0.0.0"
 description = ""
 authors = []
+package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.8"


### PR DESCRIPTION
The pyproject.toml in the packages directory describes the information of each package, and the root is simply for managing scripts.
