### PR TITLE
Remove unnecessary pinning

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1199,4 +1199,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "4d2c008815e494c56a59d3cfa2f4391dff16659dc00b47373a1fca1b47d826fa"
+content-hash = "6611a5b79d953625a510c167513cae744b1811765fbd1ae32dd6949302a2b742"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,6 @@ poethepoet = "*"
 setuptools-scm = "*"
 build = "*"
 twine = "*"
-# https://github.com/python-poetry/poetry/issues/9293
-docutils = "!=0.21.post1"
 mypy = "*"
 
 [build-system]


### PR DESCRIPTION
Pinned docutils not to 0.21.post1 to resolve the issue that it could not be found.
This is no longer necessary, so I remove it from the pyproject.toml file and update the lock file.
