### PR TITLE
Clean up versioning and exports

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -44,6 +44,9 @@ jobs:
           poetry install
           poetry run poe install-all
 
+      - name: Build
+        run: poetry run poe build-all
+
       - name: Lint
         run: poetry run poe check-all
 

--- a/packages/kitsuyui-animal/pyproject.toml
+++ b/packages/kitsuyui-animal/pyproject.toml
@@ -32,8 +32,7 @@ package-dir = { "" = "src" }
 
 [tool.setuptools_scm]
 version_file = "./src/kitsuyui/animal/_version.py"
-root = "../../"
-relative_to = "__file__"
+root = "../.."
 
 [tool.pytest.ini_options]
 pythonpath = ["src"]

--- a/packages/kitsuyui-animal/src/kitsuyui/animal/__init__.py
+++ b/packages/kitsuyui-animal/src/kitsuyui/animal/__init__.py
@@ -1,4 +1,21 @@
+"""A package for animals.
+
+This package provides a simple class `Animal` and a subclass `Dog` to represent animals.
+This package is just for example.
+
+Example:
+    >>> import kitsuyui.animal
+    >>> dog = kitsuyui.animal.Dog("Rex")
+    >>> dog.speak()
+    'Bark'
+    >>> kitsuyui.animal.example()
+    Bark
+"""
+
 import abc
+
+# https://packaging-guide.openastronomy.org/en/latest/advanced/versioning.html
+from ._version import __version__
 
 
 class Animal:
@@ -18,3 +35,11 @@ class Dog(Animal):
 def example():
     dog = Dog("Rex")
     print(dog.speak())  # Bark
+
+
+__all__ = [
+    "__version__",
+    "Animal",
+    "Dog",
+    "example",
+]

--- a/packages/kitsuyui-hello/pyproject.toml
+++ b/packages/kitsuyui-hello/pyproject.toml
@@ -32,8 +32,7 @@ package-dir = { "" = "src" }
 
 [tool.setuptools_scm]
 version_file = "./src/kitsuyui/hello/_version.py"
-root = "../../"
-relative_to = "__file__"
+root = "../.."
 
 [tool.pytest.ini_options]
 pythonpath = ["src"]

--- a/packages/kitsuyui-hello/src/kitsuyui/hello/__init__.py
+++ b/packages/kitsuyui-hello/src/kitsuyui/hello/__init__.py
@@ -1,6 +1,33 @@
+"""Hello, World! package.
+
+This package provides a simple function to generate a greeting message "Hello, World!".
+And also provides a function to print the message.
+This package is just for example.
+
+Example:
+    >>> import kitsuyui.hello
+    >>> kitsuyui.hello.hello_world()
+    'Hello, World!'
+    >>> kitsuyui.hello.print_hello_world()
+    Hello, World!
+"""
+
+# https://packaging-guide.openastronomy.org/en/latest/advanced/versioning.html
+from ._version import __version__
+
+
 def hello_world() -> str:
+    """Generate greeting message "Hello, World!"."""
     return "Hello, World!"
 
 
 def print_hello_world():
+    """Print greeting message "Hello, World!"."""
     print(hello_world())
+
+
+__all__ = [
+    "__version__",
+    "hello_world",
+    "print_hello_world",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,8 +63,8 @@ check-publish-all = [
     { cmd = "twine check dist/*", cwd = "packages/kitsuyui-animal" },
 ]
 clean-all = [
-    { cmd = "rm -rf dist", cwd = "packages/kitsuyui-hello" },
-    { cmd = "rm -rf dist", cwd = "packages/kitsuyui-animal" },
+    { cmd = "rm -rf dist src/*.egg-info", cwd = "packages/kitsuyui-hello" },
+    { cmd = "rm -rf dist src/*.egg-info", cwd = "packages/kitsuyui-animal" },
 ]
 
 [tool.mypy]


### PR DESCRIPTION
- Export `__version__` in the `__init__.py` of each package.
- Remove unused `pyproject.toml` entries related to `setuptools_scm` versioning.
- Enhance `poetry poe clean-all` task to remove `src/*.egg-info` directories.
