### PR TITLE
Fix: run-each command

### DIFF
--- a/bin/run-each
+++ b/bin/run-each
@@ -4,9 +4,11 @@ set -euo pipefail
 subcommand=$1
 shift
 
+# Use xargs instead find -exec to pass exit status.
+
 find packages \
 -type d \
 -not -path 'packages/dev-shared' \
 -maxdepth 1 \
 -mindepth 1 \
--exec sh -c 'cd {} && uv run poe '"$subcommand" \;
+| xargs -P 1 -n 1 -I {} sh -c "cd '{}' && uv run poe $subcommand"


### PR DESCRIPTION
- Currently, the `run-each` command doesn't fail if any of child processes fail.
- This commit fixes it.
