### PR TITLE
Migrate tool.uv.dev-dependencies to dependency-groups.dev

### DIFF
--- a/packages/kitsuyui-animal/pyproject.toml
+++ b/packages/kitsuyui-animal/pyproject.toml
@@ -31,8 +31,8 @@ include = ["kitsuyui.animal"]
 version_file = "./src/kitsuyui/animal/_version.py"
 root = "../.."
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "dev-shared",
 ]
 

--- a/packages/kitsuyui-hello/pyproject.toml
+++ b/packages/kitsuyui-hello/pyproject.toml
@@ -31,8 +31,8 @@ include = ["kitsuyui.hello"]
 version_file = "./src/kitsuyui/hello/_version.py"
 root = "../.."
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "dev-shared",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,8 @@ Homepage = "https://github.com/kitsuyui/pypi-playground"
 [tool.uv.workspace]
 members = ["packages/*"]
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "poethepoet",
 ]
 


### PR DESCRIPTION
To comply with PEP 735 https://packaging.python.org/en/latest/specifications/dependency-groups/
UV supports PEP 735 after v0.4.27 https://github.com/astral-sh/uv/releases/tag/0.4.27
