### PR TITLE
Add uv dependency age policy settings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,12 @@ Homepage = "https://github.com/kitsuyui/pypi-playground"
 [tool.uv.workspace]
 members = ["packages/*"]
 
+[tool.uv]
+# Source of truth:
+# https://github.com/kitsuyui/kitsuyui/wiki/Official-Information-for-Dependency-Update-Policies
+# PyPI policy in this repo uses a 2 day quarantine window.
+exclude-newer = "2 days"
+
 [dependency-groups]
 dev = [
     "poethepoet",
@@ -36,4 +42,3 @@ type_check = { cmd = "./bin/run-each type_check" }
 test = { cmd = "./bin/run-each test" }
 coverage = { cmd = "./bin/run-each coverage" }
 build = { cmd = "./bin/run-each build" }
-

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,10 @@ version = 1
 revision = 3
 requires-python = ">=3.10"
 
+[options]
+exclude-newer = "2026-04-02T20:14:37.887435Z"
+exclude-newer-span = "P2D"
+
 [manifest]
 members = [
     "dev-shared",


### PR DESCRIPTION
## Summary
- add `[tool.uv].exclude-newer = "2 days"` to `pyproject.toml`
- add inline comments that point to the source-of-truth wiki page
- run `uv sync` so the lockfile reflects the new policy

## Reference
- https://github.com/kitsuyui/kitsuyui/wiki/Official-Information-for-Dependency-Update-Policies