### PR TITLE
Share Ruff config from dev-shared

### DIFF
--- a/packages/dev-shared/poe.tasks.toml
+++ b/packages/dev-shared/poe.tasks.toml
@@ -1,10 +1,10 @@
 [tool.poe.tasks]
 
 format = [
-    {cmd = "ruff format src tests"},
+    {cmd = "ruff format src tests --config ../dev-shared/ruff.toml"},
 ]
 syntax_check = [
-    {cmd = "ruff check src tests"},
+    {cmd = "ruff check src tests --config ../dev-shared/ruff.toml"},
 ]
 type_check = [
     {cmd = "env MYPYPATH=src mypy --namespace-packages --explicit-package-bases src tests"},

--- a/packages/dev-shared/pyproject.toml
+++ b/packages/dev-shared/pyproject.toml
@@ -17,32 +17,3 @@ dependencies = [
     "mypy",
     "ty>=0.0.1a32",
 ]
-
-[tool.ruff]
-line-length = 79
-
-[tool.ruff.lint]
-select = [
-    "A",
-    "ANN",
-    "ARG",
-    "B",
-    "C4",
-    "C90",
-    "E",
-    "F",
-    "I",
-    "PERF",
-    "PLE",
-    "PTH",
-    "RET",
-    "RUF",
-    "S",
-    "SIM",
-    "SLOT",
-    "UP",
-    "W",
-]
-
-[tool.ruff.lint.per-file-ignores]
-"tests/**/*.py" = ["ANN", "D", "S101"]

--- a/packages/dev-shared/ruff.toml
+++ b/packages/dev-shared/ruff.toml
@@ -25,3 +25,4 @@ select = [
 
 [lint.per-file-ignores]
 "tests/**/*.py" = ["ANN", "D", "S101"]
+"src/**/_version.py" = ["RUF022"]

--- a/packages/dev-shared/ruff.toml
+++ b/packages/dev-shared/ruff.toml
@@ -1,0 +1,27 @@
+line-length = 79
+
+[lint]
+select = [
+    "A",
+    "ANN",
+    "ARG",
+    "B",
+    "C4",
+    "C90",
+    "E",
+    "F",
+    "I",
+    "PERF",
+    "PLE",
+    "PTH",
+    "RET",
+    "RUF",
+    "S",
+    "SIM",
+    "SLOT",
+    "UP",
+    "W",
+]
+
+[lint.per-file-ignores]
+"tests/**/*.py" = ["ANN", "D", "S101"]

--- a/packages/kitsuyui-animal/src/kitsuyui/animal/__init__.py
+++ b/packages/kitsuyui-animal/src/kitsuyui/animal/__init__.py
@@ -1,6 +1,7 @@
 """A package for animals.
 
-This package provides a simple class `Animal` and a subclass `Dog` to represent animals.
+This package provides a simple class `Animal`
+and a subclass `Dog` to represent animals.
 This package is just for example.
 
 Example:
@@ -19,27 +20,27 @@ from ._version import __version__
 
 
 class Animal:
-    def __init__(self, name):
+    def __init__(self, name: str) -> None:
         self.name = name
 
     @abc.abstractmethod
-    def speak(self):
+    def speak(self) -> str:
         raise NotImplementedError("Subclass must implement abstract method")
 
 
 class Dog(Animal):
-    def speak(self):
+    def speak(self) -> str:
         return "Bark"
 
 
-def example():
+def example() -> None:
     dog = Dog("Rex")
     print(dog.speak())  # Bark
 
 
 __all__ = [
-    "__version__",
     "Animal",
     "Dog",
+    "__version__",
     "example",
 ]

--- a/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/__init__.py
+++ b/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/__init__.py
@@ -5,14 +5,13 @@ This package provides content-addressable storage functionality.
 
 # https://packaging-guide.openastronomy.org/en/latest/advanced/versioning.html
 from ._version import __version__
-
 from .hash_store import HashStore
-from .hasher import register_hasher_factory
 from .hash_store.base_store import register_store_factory
+from .hasher import register_hasher_factory
 
 __all__ = [
-    "__version__",
     "HashStore",
+    "__version__",
     "register_hasher_factory",
     "register_store_factory",
 ]

--- a/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/__init__.py
+++ b/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/__init__.py
@@ -1,19 +1,18 @@
 from __future__ import annotations
 
-from typing import Literal, Any
-
 from dataclasses import dataclass
+from typing import Literal
 
-from .base_store import BaseStoreProtocol
-from ..types import RawItem, HashValue
 from ..exceptions import ItemAlreadyExists
-from ..hasher.types import HasherProtocol
 from ..hasher import factory as hasher_factory
+from ..hasher.types import HasherProtocol
+from ..types import HashValue, RawItem
+from .base_store import BaseStoreProtocol
 from .base_store import factory as store_factory
-
 
 ConflictAction = Literal["overwrite", "error", "ignore"]
 VerifyAction = Literal["delete", "error", "ignore"]
+StoreConfig = dict[str, str | None]
 
 
 @dataclass
@@ -26,8 +25,8 @@ class HashStore:
         cls,
         hasher_name: str,
         store_name: str,
-        hasher_config: Any = None,
-        store_config: Any = None,
+        hasher_config: object | None = None,
+        store_config: StoreConfig | None = None,
     ) -> HashStore:
         return factory(
             hasher_name=hasher_name,
@@ -53,12 +52,14 @@ class HashStore:
         self.base_store.delete(hash_value)
 
     def is_valid_stored_item(self, hash_value: HashValue) -> bool:
-        """Validate the already stored item by recomputing its hash and comparing it to the given hash value."""
+        """Validate a stored item by recomputing its hash."""
         item = self.retrieve(hash_value)
         computed_hash = self.compute_hash(item)
         return computed_hash == hash_value
 
-    def verify(self, hash_value: HashValue, *, action: VerifyAction = "error") -> bool:
+    def verify(
+        self, hash_value: HashValue, *, action: VerifyAction = "error"
+    ) -> bool:
         """Verify the stored item with the given hash value.
         action:
             - 'delete': delete the item if invalid
@@ -129,8 +130,8 @@ class HashStore:
 def factory(
     hasher_name: str,
     store_name: str,
-    hasher_config: Any = None,
-    store_config: Any = None,
+    hasher_config: object | None = None,
+    store_config: StoreConfig | None = None,
 ) -> HashStore:
     """Factory function for creating a HashStore instance."""
     hasher = hasher_factory(hasher_name, hasher_config)
@@ -139,7 +140,7 @@ def factory(
 
 
 __all__ = [
-    "HashStore",
     "BaseStoreProtocol",
     "ConflictAction",
+    "HashStore",
 ]

--- a/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/async_dict_store.py
+++ b/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/async_dict_store.py
@@ -1,8 +1,8 @@
 import asyncio
 
+from ..types import HashValue, RawItem
 from .base_store import AsyncBaseStoreProtocol
 from .dict_store import DictStore
-from ..types import HashValue, RawItem
 
 
 class AsyncDictStore(AsyncBaseStoreProtocol):

--- a/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/base_store.py
+++ b/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/base_store.py
@@ -1,17 +1,18 @@
 from __future__ import annotations
 
 import asyncio
-
-from typing import Protocol, Callable
 import functools
+from collections.abc import Callable
+from typing import ParamSpec, Protocol, TypeVar
 
-from ..types import RawItem, HashValue
+from ..types import HashValue, RawItem
 
 
 class BaseStoreProtocol(Protocol):
     """Protocol for a basic hash store.
 
-    This defines the essential methods that any hash store implementation must provide.
+    This defines the essential methods that any hash store
+    implementation must provide.
     More specific methods are defined in HashStore
     """
 
@@ -37,7 +38,8 @@ class BaseStoreProtocol(Protocol):
 class AsyncBaseStoreProtocol(Protocol):
     """Protocol for an asynchronous basic hash store.
 
-    This defines the essential methods that any async hash store implementation must provide.
+    This defines the essential methods that any async hash store
+    implementation must provide.
     More specific methods are defined in HashStore
     """
 
@@ -60,13 +62,17 @@ class AsyncBaseStoreProtocol(Protocol):
         """Destroy the store and clean up any resources."""
 
 
+P = ParamSpec("P")
+TStore = TypeVar("TStore", bound="BaseStoreProtocol")
+
+
 def wrap_async_store_as_sync(
     name: str, async_store_class: type[AsyncBaseStoreProtocol]
 ) -> type[BaseStoreProtocol]:
     """Convert an asynchronous store to a synchronous store."""
 
     class Wrapped(BaseStoreProtocol):
-        def __init__(self, *args, **kwargs) -> None:
+        def __init__(self, *args: object, **kwargs: object) -> None:
             self.async_store = async_store_class(*args, **kwargs)
 
         def store_item(self, hash_value: HashValue, item: RawItem) -> None:
@@ -94,12 +100,16 @@ def wrap_async_store_as_sync(
 STORE_FACTORIES: dict[str, Callable[..., BaseStoreProtocol]] = {}
 
 
-def __register_store(name: str, factory: Callable[..., BaseStoreProtocol]) -> None:
+def __register_store(
+    name: str, factory: Callable[..., BaseStoreProtocol]
+) -> None:
     """Register a store class with the given name."""
     STORE_FACTORIES[name] = factory
 
 
-def register_store_factory(name: str):
+def register_store_factory(
+    name: str,
+) -> Callable[[Callable[P, TStore]], Callable[P, TStore]]:
     """Decorator for registering a store factory function.
 
     Usage:
@@ -109,22 +119,21 @@ def register_store_factory(name: str):
         ...
     """
 
-    def decorator(
-        factory: Callable[..., BaseStoreProtocol],
-    ) -> Callable[..., BaseStoreProtocol]:
+    def decorator(factory: Callable[P, TStore]) -> Callable[P, TStore]:
         __register_store(name, factory)
 
         @functools.wraps(factory)
-        def wrapper(*args, **kwargs) -> BaseStoreProtocol:
-            store_class = factory(*args, **kwargs)
-            return store_class
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> TStore:
+            return factory(*args, **kwargs)
 
         return wrapper
 
     return decorator
 
 
-def factory(name: str, *args, **kwargs) -> BaseStoreProtocol:
+def factory(
+    name: str, *args: object, **kwargs: object
+) -> BaseStoreProtocol:
     """Factory function for creating a store instance by name."""
     if name not in STORE_FACTORIES:
         raise ValueError(f"Store '{name}' is not registered.")

--- a/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/dict_store.py
+++ b/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/dict_store.py
@@ -1,6 +1,5 @@
-from typing import Any
-from .base_store import BaseStoreProtocol, register_store_factory
 from ..types import HashValue, RawItem
+from .base_store import BaseStoreProtocol, register_store_factory
 
 
 class DictStore(BaseStoreProtocol):
@@ -31,6 +30,6 @@ class DictStore(BaseStoreProtocol):
 
 
 @register_store_factory("dict_store")
-def factory(config: Any) -> BaseStoreProtocol:
+def factory(_config: object | None = None) -> BaseStoreProtocol:
     """Factory function for creating a DictStore class."""
     return DictStore()

--- a/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/filesystem_store.py
+++ b/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/filesystem_store.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import pathlib
+from typing import cast
 
-from typing import Any
-from .base_store import BaseStoreProtocol, register_store_factory
 from ..types import HashValue, RawItem
+from .base_store import BaseStoreProtocol, register_store_factory
 
 
 class FileSystemStore(BaseStoreProtocol):
@@ -20,7 +20,7 @@ class FileSystemStore(BaseStoreProtocol):
 
     def store_item(self, hash_value: HashValue, item: RawItem) -> None:
         file_path = self.parent_dir / hash_value.hex()
-        with open(file_path, "wb") as f:
+        with file_path.open("wb") as f:
             f.write(item)
 
     def stores(self, hash_value: HashValue) -> bool:
@@ -29,7 +29,7 @@ class FileSystemStore(BaseStoreProtocol):
 
     def retrieve(self, hash_value: HashValue) -> RawItem:
         file_path = self.parent_dir / hash_value.hex()
-        with open(file_path, "rb") as f:
+        with file_path.open("rb") as f:
             return f.read()
 
     def delete(self, hash_value: HashValue) -> None:
@@ -47,7 +47,7 @@ class FileSystemStore(BaseStoreProtocol):
 
 
 @register_store_factory("filesystem_store")
-def factory(config: Any) -> BaseStoreProtocol:
+def factory(config: object | None = None) -> BaseStoreProtocol:
     """Factory function for creating a FileSystemStore class."""
 
     repo_key = "repo_dir"
@@ -55,7 +55,8 @@ def factory(config: Any) -> BaseStoreProtocol:
     if not isinstance(config, dict) or repo_key not in config:
         raise ValueError("Invalid config for FileSystemStore")
 
-    repo_dir = config[repo_key]
+    typed_config = cast(dict[str, object], config)
+    repo_dir = typed_config[repo_key]
     if not isinstance(repo_dir, (str, pathlib.Path)):
         raise ValueError(f"{repo_key} must be a string or pathlib.Path")
 

--- a/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hasher/__init__.py
+++ b/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hasher/__init__.py
@@ -1,9 +1,13 @@
-import hashlib
-from typing import Any, Callable
 import functools
+import hashlib
+from collections.abc import Callable
+from typing import ParamSpec, TypeVar
 
+from ..types import HashValue, RawItem
 from .types import HasherProtocol
-from ..types import RawItem, HashValue
+
+P = ParamSpec("P")
+THasher = TypeVar("THasher", bound=HasherProtocol)
 
 
 """
@@ -30,12 +34,16 @@ def generate_hasher(name: str) -> type[HasherProtocol]:
 HASHER_REGISTRY: dict[str, Callable[..., HasherProtocol]] = {}
 
 
-def __register_hasher(name: str, hasher_factory: Callable[..., HasherProtocol]) -> None:
+def __register_hasher(
+    name: str, hasher_factory: Callable[..., HasherProtocol]
+) -> None:
     """Register a hasher class with the given name."""
     HASHER_REGISTRY[name] = hasher_factory
 
 
-def register_hasher_factory(name: str):
+def register_hasher_factory(
+    name: str,
+) -> Callable[[Callable[P, THasher]], Callable[P, THasher]]:
     """Decorator for registering a hasher factory function.
 
     Usage:
@@ -45,22 +53,19 @@ def register_hasher_factory(name: str):
         ...
     """
 
-    def decorator(
-        factory: Callable[..., HasherProtocol],
-    ) -> Callable[..., HasherProtocol]:
+    def decorator(factory: Callable[P, THasher]) -> Callable[P, THasher]:
         __register_hasher(name, factory)
 
         @functools.wraps(factory)
-        def wrapper(*args, **kwargs) -> HasherProtocol:
-            hasher = factory(*args, **kwargs)
-            return hasher
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> THasher:
+            return factory(*args, **kwargs)
 
         return wrapper
 
     return decorator
 
 
-def factory(name: str, *args, **kwargs) -> HasherProtocol:
+def factory(name: str, *args: object, **kwargs: object) -> HasherProtocol:
     """Factory function for creating a hasher instance by name."""
     if name not in HASHER_REGISTRY:
         raise ValueError(f"Hasher '{name}' is not registered.")
@@ -73,21 +78,21 @@ MD5Hasher = generate_hasher("md5")
 
 
 @register_hasher_factory("sha256")
-def sha256_factory(config: Any) -> HasherProtocol:
+def sha256_factory(_config: object | None = None) -> HasherProtocol:
     """Factory function for creating a SHA256Hasher class."""
     return SHA256Hasher()
 
 
 @register_hasher_factory("md5")
-def md5_factory(config: Any) -> HasherProtocol:
+def md5_factory(_config: object | None = None) -> HasherProtocol:
     """Factory function for creating a MD5Hasher class."""
     return MD5Hasher()
 
 
 __all__ = [
     "HasherProtocol",
-    "SHA256Hasher",
     "MD5Hasher",
+    "SHA256Hasher",
     "generate_hasher",
     "register_hasher_factory",
 ]

--- a/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hasher/types.py
+++ b/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hasher/types.py
@@ -1,6 +1,6 @@
 from typing import Protocol
 
-from ..types import RawItem, HashValue
+from ..types import HashValue, RawItem
 
 
 class HasherProtocol(Protocol):

--- a/packages/kitsuyui-content_addr/tests/test_hash_store.py
+++ b/packages/kitsuyui-content_addr/tests/test_hash_store.py
@@ -1,10 +1,11 @@
 import tempfile
+
 import pytest
 
-from kitsuyui.content_addr.hash_store import HashStore, factory
-from kitsuyui.content_addr.hasher import SHA256Hasher
-from kitsuyui.content_addr.hash_store.dict_store import DictStore
 from kitsuyui.content_addr.exceptions import ItemAlreadyExists
+from kitsuyui.content_addr.hash_store import HashStore, factory
+from kitsuyui.content_addr.hash_store.dict_store import DictStore
+from kitsuyui.content_addr.hasher import SHA256Hasher
 
 
 def test_example_usage() -> None:
@@ -24,10 +25,10 @@ def test_hash_store() -> None:
     retrieved_item = store.retrieve(hash_value)
     assert retrieved_item == item
 
-    # storing the same item again should be fine (default conflict action is 'ignore')
+    # Storing the same item again should be fine.
     store.store(item)
 
-    # trying to store the same item with conflict action 'error' should raise ItemAlreadyExists
+    # Conflict action "error" should raise ItemAlreadyExists.
     with pytest.raises(ItemAlreadyExists):
         store.store(item, conflicts="error")
 
@@ -40,7 +41,7 @@ def test_hash_store() -> None:
     with pytest.raises(ValueError):
         store.verify(hash_value, action="error")
 
-    # overwrite the corrupted item with the correct one and test overwrite action
+    # Overwrite the corrupted item with the correct one.
     store.store(item, conflicts="overwrite")
     assert store.verify(hash_value, action="ignore")
 

--- a/packages/kitsuyui-content_addr/tests/test_hash_store_async_dict_store.py
+++ b/packages/kitsuyui-content_addr/tests/test_hash_store_async_dict_store.py
@@ -1,5 +1,7 @@
 from kitsuyui.content_addr.hash_store.async_dict_store import AsyncDictStore
-from kitsuyui.content_addr.hash_store.base_store import wrap_async_store_as_sync
+from kitsuyui.content_addr.hash_store.base_store import (
+    wrap_async_store_as_sync,
+)
 
 
 def test_async_dict_store_store_and_retrieve() -> None:

--- a/packages/kitsuyui-content_addr/tests/test_hash_store_filesystem_store.py
+++ b/packages/kitsuyui-content_addr/tests/test_hash_store_filesystem_store.py
@@ -3,7 +3,10 @@ import tempfile
 
 import pytest
 
-from kitsuyui.content_addr.hash_store.filesystem_store import FileSystemStore, factory
+from kitsuyui.content_addr.hash_store.filesystem_store import (
+    FileSystemStore,
+    factory,
+)
 
 
 @pytest.fixture(scope="function", autouse=True)

--- a/packages/kitsuyui-content_addr/tests/test_hasher.py
+++ b/packages/kitsuyui-content_addr/tests/test_hasher.py
@@ -1,4 +1,4 @@
-from kitsuyui.content_addr.hasher import SHA256Hasher, MD5Hasher
+from kitsuyui.content_addr.hasher import MD5Hasher, SHA256Hasher
 
 
 def test_sha256_hasher() -> None:

--- a/packages/kitsuyui-hello/src/kitsuyui/hello/__init__.py
+++ b/packages/kitsuyui-hello/src/kitsuyui/hello/__init__.py
@@ -1,6 +1,7 @@
 """Hello, World! package.
 
-This package provides a simple function to generate a greeting message "Hello, World!".
+This package provides a simple function to generate
+a greeting message "Hello, World!".
 And also provides a function to print the message.
 This package is just for example.
 
@@ -21,7 +22,7 @@ def hello_world() -> str:
     return "Hello, World!"
 
 
-def print_hello_world():
+def print_hello_world() -> None:
     """Print greeting message "Hello, World!"."""
     print(hello_world())
 


### PR DESCRIPTION
## Summary

- move the shared Ruff settings out of `packages/dev-shared/pyproject.toml` into `packages/dev-shared/ruff.toml`
- update the shared Poe tasks to pass `--config ../dev-shared/ruff.toml`, so each package actually uses the shared Ruff rules
- adjust the existing packages to satisfy the stricter shared Ruff configuration

## Verification

- `uv run poe check`
- `uv run poe test`
