### PR TITLE
Add Ruff McCabe complexity ratchet

### DIFF
--- a/packages/dev-shared/ruff.toml
+++ b/packages/dev-shared/ruff.toml
@@ -28,4 +28,4 @@ select = [
 "src/**/_version.py" = ["RUF022"]
 
 [lint.mccabe]
-max-complexity = 6
+max-complexity = 5

--- a/packages/dev-shared/ruff.toml
+++ b/packages/dev-shared/ruff.toml
@@ -28,4 +28,4 @@ select = [
 "src/**/_version.py" = ["RUF022"]
 
 [lint.mccabe]
-max-complexity = 5
+max-complexity = 3

--- a/packages/dev-shared/ruff.toml
+++ b/packages/dev-shared/ruff.toml
@@ -26,3 +26,6 @@ select = [
 [lint.per-file-ignores]
 "tests/**/*.py" = ["ANN", "D", "S101"]
 "src/**/_version.py" = ["RUF022"]
+
+[lint.mccabe]
+max-complexity = 8

--- a/packages/dev-shared/ruff.toml
+++ b/packages/dev-shared/ruff.toml
@@ -28,4 +28,4 @@ select = [
 "src/**/_version.py" = ["RUF022"]
 
 [lint.mccabe]
-max-complexity = 8
+max-complexity = 6

--- a/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/__init__.py
+++ b/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/__init__.py
@@ -84,6 +84,42 @@ class HashStore:
     def _store_raw(self, hash_value: HashValue, item: RawItem) -> None:
         self.base_store.store_item(hash_value, item)
 
+    def _store_overwriting(
+        self, hash_value: HashValue, item: RawItem
+    ) -> None:
+        self._store_raw(hash_value, item)
+
+    def _store_with_error_on_conflict(
+        self, hash_value: HashValue, item: RawItem
+    ) -> None:
+        if self.stores(hash_value):
+            raise ItemAlreadyExists(
+                f"Item with hash {hash_value.hex()} already exists."
+            )
+        self._store_raw(hash_value, item)
+
+    def _store_ignoring_conflicts(
+        self, hash_value: HashValue, item: RawItem
+    ) -> None:
+        if not self.stores(hash_value):
+            self._store_raw(hash_value, item)
+
+    def _store_with_conflict_policy(
+        self,
+        hash_value: HashValue,
+        item: RawItem,
+        conflicts: ConflictAction,
+    ) -> None:
+        handlers = {
+            "overwrite": self._store_overwriting,
+            "error": self._store_with_error_on_conflict,
+            "ignore": self._store_ignoring_conflicts,
+        }
+        handler = handlers.get(conflicts)
+        if handler is None:
+            raise ValueError(f"Invalid conflict action: {conflicts}")
+        handler(hash_value, item)
+
     def store(
         self, item: RawItem, *, conflicts: ConflictAction = "ignore"
     ) -> HashValue:
@@ -94,19 +130,7 @@ class HashStore:
             - 'ignore': do nothing if item already exists (default)
         """
         hash_value = self.compute_hash(item)
-        if conflicts == "overwrite":
-            self._store_raw(hash_value, item)
-        elif conflicts == "error":
-            if self.stores(hash_value):
-                raise ItemAlreadyExists(
-                    f"Item with hash {hash_value.hex()} already exists."
-                )
-            self._store_raw(hash_value, item)
-        elif conflicts == "ignore":
-            if not self.stores(hash_value):
-                self.base_store.store_item(hash_value, item)
-        else:
-            raise ValueError(f"Invalid conflict action: {conflicts}")
+        self._store_with_conflict_policy(hash_value, item, conflicts)
         return hash_value
 
     def store_if_not_exists(self, item: RawItem) -> HashValue:

--- a/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/__init__.py
+++ b/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/__init__.py
@@ -57,6 +57,30 @@ class HashStore:
         computed_hash = self.compute_hash(item)
         return computed_hash == hash_value
 
+    def _delete_invalid_stored_item(self, hash_value: HashValue) -> None:
+        self.delete(hash_value)
+
+    def _raise_invalid_stored_item(self, hash_value: HashValue) -> None:
+        raise ValueError(
+            f"Stored item with hash {hash_value.hex()} is invalid."
+        )
+
+    def _ignore_invalid_stored_item(self, _hash_value: HashValue) -> None:
+        return None
+
+    def _handle_invalid_stored_item(
+        self, hash_value: HashValue, action: VerifyAction
+    ) -> None:
+        handlers = {
+            "delete": self._delete_invalid_stored_item,
+            "error": self._raise_invalid_stored_item,
+            "ignore": self._ignore_invalid_stored_item,
+        }
+        handler = handlers.get(action)
+        if handler is None:
+            raise ValueError(f"Invalid verify action: {action}")
+        handler(hash_value)
+
     def verify(
         self, hash_value: HashValue, *, action: VerifyAction = "error"
     ) -> bool:
@@ -68,18 +92,10 @@ class HashStore:
         Returns True if the item is valid, False otherwise.
         """
         is_valid = self.is_valid_stored_item(hash_value)
-        if not is_valid:
-            if action == "delete":
-                self.delete(hash_value)
-            elif action == "error":
-                raise ValueError(
-                    f"Stored item with hash {hash_value.hex()} is invalid."
-                )
-            elif action == "ignore":
-                pass
-            else:
-                raise ValueError(f"Invalid verify action: {action}")
-        return is_valid
+        if is_valid:
+            return True
+        self._handle_invalid_stored_item(hash_value, action)
+        return False
 
     def _store_raw(self, hash_value: HashValue, item: RawItem) -> None:
         self.base_store.store_item(hash_value, item)

--- a/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/base_store.py
+++ b/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/base_store.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import functools
 from collections.abc import Callable
-from typing import ParamSpec, Protocol, TypeVar
+from typing import ClassVar, ParamSpec, Protocol, TypeVar, cast
 
 from ..types import HashValue, RawItem
 
@@ -66,33 +66,50 @@ P = ParamSpec("P")
 TStore = TypeVar("TStore", bound="BaseStoreProtocol")
 
 
+class SyncWrappedStoreBase(BaseStoreProtocol):
+    """Base class for sync adapters backed by an async store."""
+
+    async_store_class: ClassVar[type[AsyncBaseStoreProtocol]]
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        self.async_store = self.async_store_class(*args, **kwargs)
+
+    def _run_async_store_method(
+        self, method_name: str, *args: object
+    ) -> object:
+        method = getattr(self.async_store, method_name)
+        return asyncio.run(method(*args))
+
+    def store_item(self, hash_value: HashValue, item: RawItem) -> None:
+        self._run_async_store_method("store_item", hash_value, item)
+
+    def stores(self, hash_value: HashValue) -> bool:
+        return cast(bool, self._run_async_store_method("stores", hash_value))
+
+    def retrieve(self, hash_value: HashValue) -> RawItem:
+        return cast(
+            RawItem, self._run_async_store_method("retrieve", hash_value)
+        )
+
+    def delete(self, hash_value: HashValue) -> None:
+        self._run_async_store_method("delete", hash_value)
+
+    def clear(self) -> None:
+        self._run_async_store_method("clear")
+
+    def destroy(self) -> None:
+        self._run_async_store_method("destroy")
+
+
 def wrap_async_store_as_sync(
     name: str, async_store_class: type[AsyncBaseStoreProtocol]
 ) -> type[BaseStoreProtocol]:
     """Convert an asynchronous store to a synchronous store."""
 
-    class Wrapped(BaseStoreProtocol):
-        def __init__(self, *args: object, **kwargs: object) -> None:
-            self.async_store = async_store_class(*args, **kwargs)
+    class Wrapped(SyncWrappedStoreBase):
+        pass
 
-        def store_item(self, hash_value: HashValue, item: RawItem) -> None:
-            return asyncio.run(self.async_store.store_item(hash_value, item))
-
-        def stores(self, hash_value: HashValue) -> bool:
-            return asyncio.run(self.async_store.stores(hash_value))
-
-        def retrieve(self, hash_value: HashValue) -> RawItem:
-            return asyncio.run(self.async_store.retrieve(hash_value))
-
-        def delete(self, hash_value: HashValue) -> None:
-            return asyncio.run(self.async_store.delete(hash_value))
-
-        def clear(self) -> None:
-            return asyncio.run(self.async_store.clear())
-
-        def destroy(self) -> None:
-            return asyncio.run(self.async_store.destroy())
-
+    Wrapped.async_store_class = async_store_class
     Wrapped.__name__ = name
     return Wrapped
 

--- a/packages/kitsuyui-content_addr/tests/test_hash_store.py
+++ b/packages/kitsuyui-content_addr/tests/test_hash_store.py
@@ -43,6 +43,8 @@ def test_hash_store() -> None:
     assert not store.verify(hash_value, action="ignore")
     with pytest.raises(ValueError):
         store.verify(hash_value, action="error")
+    with pytest.raises(ValueError):
+        store.verify(hash_value, action="unexpected")  # type: ignore[arg-type]
 
     # Overwrite the corrupted item with the correct one.
     store.store(item, conflicts="overwrite")

--- a/packages/kitsuyui-content_addr/tests/test_hash_store.py
+++ b/packages/kitsuyui-content_addr/tests/test_hash_store.py
@@ -32,6 +32,9 @@ def test_hash_store() -> None:
     with pytest.raises(ItemAlreadyExists):
         store.store(item, conflicts="error")
 
+    with pytest.raises(ValueError):
+        store.store(item, conflicts="unexpected")  # type: ignore[arg-type]
+
     # validate stored item should return True
     assert store.verify(hash_value, action="ignore")
 


### PR DESCRIPTION
## Summary
- add Ruff McCabe max-complexity with an initial zero-hit threshold of 8
- lower the threshold in follow-up commits to 6, 5, and 3
- refactor the async store adapter and HashStore conflict/verify policy handling without changing public interfaces

## Notes
- threshold 2 still flags small decorator factories and filesystem helpers, so this PR stops at 3 to avoid forced micro-splitting

## Testing
- uv run poe check
- uv run poe test
- uv run poe build
