### PR TITLE
Publish content-addr package artifacts

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        targets: ['kitsuyui-animal', 'kitsuyui-hello']
+        targets: ['kitsuyui-animal', 'kitsuyui-content_addr', 'kitsuyui-hello']
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary
- Add `kitsuyui-content_addr` to the publish matrix.
- Align the release upload targets with the workspace packages built by the workflow.

## Verification
- `uv run poe build`
