### PR TITLE
ci: add workflow permissions for PyPI publish

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -10,9 +10,14 @@ on:
 env:
   python_version: 3.13
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## What changed

- Add `permissions: contents: read` at workflow level for `.github/workflows/pypi-publish.yml`.
- Add `permissions: contents: read` to `deploy` job.

## Why

The workflow uses `secrets.PYPI_API_TOKEN` / `secrets.TEST_PYPI_API_TOKEN` but had no explicit permissions, so publish boundaries were not explicitly constrained.

## Validation

- `uv sync --no-dev`
- `uv run poe check`
