### PR TITLE
Fix sync wrapper for async stores inside event loops

### DIFF
--- a/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/base_store.py
+++ b/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/base_store.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import asyncio
 import functools
-from collections.abc import Callable
-from typing import ClassVar, ParamSpec, Protocol, TypeVar, cast
+from collections.abc import Callable, Coroutine
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any, ClassVar, ParamSpec, Protocol, TypeVar, cast
 
 from ..types import HashValue, RawItem
 
@@ -63,7 +64,42 @@ class AsyncBaseStoreProtocol(Protocol):
 
 
 P = ParamSpec("P")
+R = TypeVar("R")
 TStore = TypeVar("TStore", bound="BaseStoreProtocol")
+AsyncStoreMethod = Callable[..., Coroutine[Any, Any, object]]
+
+
+def _has_running_loop() -> bool:
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return False
+    return True
+
+
+def _run_coroutine(
+    coroutine_factory: Callable[[], Coroutine[Any, Any, R]],
+) -> R:
+    return asyncio.run(coroutine_factory())
+
+
+def _run_coroutine_in_thread(
+    coroutine_factory: Callable[[], Coroutine[Any, Any, R]],
+) -> R:
+    def run() -> R:
+        return _run_coroutine(coroutine_factory)
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        future = executor.submit(run)
+        return future.result()
+
+
+def _run_coroutine_sync(
+    coroutine_factory: Callable[[], Coroutine[Any, Any, R]],
+) -> R:
+    if _has_running_loop():
+        return _run_coroutine_in_thread(coroutine_factory)
+    return _run_coroutine(coroutine_factory)
 
 
 class SyncWrappedStoreBase(BaseStoreProtocol):
@@ -77,8 +113,8 @@ class SyncWrappedStoreBase(BaseStoreProtocol):
     def _run_async_store_method(
         self, method_name: str, *args: object
     ) -> object:
-        method = getattr(self.async_store, method_name)
-        return asyncio.run(method(*args))
+        method = cast(AsyncStoreMethod, getattr(self.async_store, method_name))
+        return _run_coroutine_sync(lambda: method(*args))
 
     def store_item(self, hash_value: HashValue, item: RawItem) -> None:
         self._run_async_store_method("store_item", hash_value, item)

--- a/packages/kitsuyui-content_addr/tests/test_hash_store_async_dict_store.py
+++ b/packages/kitsuyui-content_addr/tests/test_hash_store_async_dict_store.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from kitsuyui.content_addr.hash_store.async_dict_store import AsyncDictStore
 from kitsuyui.content_addr.hash_store.base_store import (
     wrap_async_store_as_sync,
@@ -36,3 +38,19 @@ def test_async_dict_store_store_and_retrieve() -> None:
     # destroy store (should be no-op for DictStore)
     store.destroy()
     assert not store.stores(hash_value)
+
+
+async def _store_and_retrieve_inside_running_loop() -> None:
+    DictStore2 = wrap_async_store_as_sync("DictStore2", AsyncDictStore)
+    store = DictStore2()
+    hash_value = b"hash1"
+    item = b"item1"
+
+    store.store_item(hash_value, item)
+
+    assert store.stores(hash_value)
+    assert store.retrieve(hash_value) == item
+
+
+def test_async_dict_store_wrapped_sync_inside_running_loop() -> None:
+    asyncio.run(_store_and_retrieve_inside_running_loop())


### PR DESCRIPTION
## Summary
- Keep `wrap_async_store_as_sync()` working when the synchronous wrapper is called from an existing `asyncio` event loop.
- Preserve the current direct `asyncio.run()` path when no event loop is running in the caller thread.
- Add regression coverage for using the wrapped `AsyncDictStore` from inside an active event loop.

## Validation
- `uv run poe test`
- `uv run poe check`
