### PR TITLE
Pin PyPI publish workflow actions

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -23,16 +23,16 @@ jobs:
       matrix:
         targets: ['kitsuyui-animal', 'kitsuyui-content_addr', 'kitsuyui-hello']
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Set up Python
         id: setup-python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: ${{ env.python_version }}
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78
 
       - name: Install dependencies
         run: |
@@ -43,7 +43,7 @@ jobs:
         run: uv run poe build
 
       - name: Publish distribution to Test PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
         if: github.event_name == 'release' && github.event.release.prerelease
         with:
           user: __token__
@@ -53,7 +53,7 @@ jobs:
 
       - name: Publish distribution to PyPI
         if: github.event_name == 'release' && !github.event.release.prerelease
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
## Summary
- Pin the PyPI publishing workflow actions to immutable commit SHAs.
- Keep the existing TestPyPI/PyPI publish conditions and token-based publishing configuration unchanged.

## Validation
- `git diff --check`
- Ruby YAML parse for `.github/workflows/pypi-publish.yml`
- `actionlint .github/workflows/pypi-publish.yml`
- `uv sync`
- `uv run poe sync-all`
- `uv run poe build`
- `uv run poe test`

## Notes
- Release publishing was not run locally.
- `uv run poe build` still emits existing setuptools deprecation/package-discovery warnings; the build completed successfully.
