### PR TITLE
Restrict test workflow permissions

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add explicit read-only `contents` permission to the test workflow.

## Verification
- `git diff --check`
- `actionlint .github/workflows/python-test.yml`