### PR TITLE
Remove MD5 from built-in content hashers

### DIFF
--- a/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hasher/__init__.py
+++ b/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hasher/__init__.py
@@ -9,6 +9,8 @@ from .types import HasherProtocol
 P = ParamSpec("P")
 THasher = TypeVar("THasher", bound=HasherProtocol)
 
+UNSAFE_HASH_ALGORITHMS = frozenset({"md5"})
+
 
 """
 Example implementation of a HasherProtocol using SHA-256:
@@ -22,6 +24,9 @@ class SHA256Hasher(HasherProtocol):
 
 
 def generate_hasher(name: str) -> type[HasherProtocol]:
+    if name.lower() in UNSAFE_HASH_ALGORITHMS:
+        raise ValueError(f"Unsafe hash algorithm is not supported: {name}")
+
     class CustomHasher(HasherProtocol):
         def compute_hash(self, item: RawItem) -> HashValue:
             raw_hasher = hashlib.new(name)
@@ -76,7 +81,6 @@ def factory(name: str, *args: object, **kwargs: object) -> HasherProtocol:
 
 
 SHA256Hasher = generate_hasher("sha256")
-MD5Hasher = generate_hasher("md5")
 
 
 @register_hasher_factory("sha256")
@@ -85,15 +89,8 @@ def sha256_factory(_config: object | None = None) -> HasherProtocol:
     return SHA256Hasher()
 
 
-@register_hasher_factory("md5")
-def md5_factory(_config: object | None = None) -> HasherProtocol:
-    """Factory function for creating a MD5Hasher class."""
-    return MD5Hasher()
-
-
 __all__ = [
     "HasherProtocol",
-    "MD5Hasher",
     "SHA256Hasher",
     "generate_hasher",
     "register_hasher_factory",

--- a/packages/kitsuyui-content_addr/tests/test_hash_store.py
+++ b/packages/kitsuyui-content_addr/tests/test_hash_store.py
@@ -93,10 +93,18 @@ def test_hash_store_factory() -> None:
 
     with tempfile.TemporaryDirectory() as temp_dir:
         store2 = factory(
-            hasher_name="md5",
+            hasher_name="sha256",
             store_name="filesystem_store",
             store_config={"repo_dir": temp_dir},
         )
         assert not store2.stores(hash_value)
         hash_value2 = store2.store(item)
         assert store2.stores(hash_value2)
+
+
+def test_hash_store_factory_rejects_md5() -> None:
+    with pytest.raises(ValueError, match="Hasher 'md5' is not registered"):
+        factory(
+            hasher_name="md5",
+            store_name="dict_store",
+        )

--- a/packages/kitsuyui-content_addr/tests/test_hasher.py
+++ b/packages/kitsuyui-content_addr/tests/test_hasher.py
@@ -1,4 +1,6 @@
-from kitsuyui.content_addr.hasher import MD5Hasher, SHA256Hasher
+import pytest
+
+from kitsuyui.content_addr.hasher import SHA256Hasher, generate_hasher
 from kitsuyui.content_addr.types import RawItem
 
 
@@ -12,9 +14,6 @@ def test_sha256_hasher() -> None:
     assert computed_hash.hex() == expected_hash_hex
 
 
-def test_md5_hasher() -> None:
-    hasher = MD5Hasher()
-    item = RawItem(b"Hello, World!")
-    expected_hash_hex = "65a8e27d8879283831b664bd8b7f0ad4"
-    computed_hash = hasher.compute_hash(item)
-    assert computed_hash.hex() == expected_hash_hex
+def test_generate_hasher_rejects_md5() -> None:
+    with pytest.raises(ValueError, match="Unsafe hash algorithm"):
+        generate_hasher("md5")


### PR DESCRIPTION
## Summary
- Remove MD5 from the registered built-in hashers for `kitsuyui.content_addr`.
- Reject `generate_hasher("md5")` so MD5 is not exposed through the package helper API.
- Update tests to cover the unsupported MD5 path while keeping SHA-256 store coverage.

## Testing
- `uv sync && uv run poe sync-all`
- `uv run poe format`
- `uv run poe check`
- `uv run poe test`
- `uv run poe coverage`
- `uv run poe build`
- `git diff --check`
- adjacent static check: `uv run poe type_check` (0 issues)
- implement-validator: overall: pass
