### PR TITLE
Guard hasher and store registries against duplicate registration

### DIFF
--- a/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/__init__.py
+++ b/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/__init__.py
@@ -100,9 +100,7 @@ class HashStore:
     def _store_raw(self, hash_value: HashValue, item: RawItem) -> None:
         self.base_store.store_item(hash_value, item)
 
-    def _store_overwriting(
-        self, hash_value: HashValue, item: RawItem
-    ) -> None:
+    def _store_overwriting(self, hash_value: HashValue, item: RawItem) -> None:
         self._store_raw(hash_value, item)
 
     def _store_with_error_on_conflict(

--- a/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/base_store.py
+++ b/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/base_store.py
@@ -157,6 +157,8 @@ def __register_store(
     name: str, factory: Callable[..., BaseStoreProtocol]
 ) -> None:
     """Register a store class with the given name."""
+    if name in STORE_FACTORIES:
+        raise ValueError(f"Store '{name}' is already registered.")
     STORE_FACTORIES[name] = factory
 
 
@@ -184,9 +186,7 @@ def register_store_factory(
     return decorator
 
 
-def factory(
-    name: str, *args: object, **kwargs: object
-) -> BaseStoreProtocol:
+def factory(name: str, *args: object, **kwargs: object) -> BaseStoreProtocol:
     """Factory function for creating a store instance by name."""
     if name not in STORE_FACTORIES:
         raise ValueError(f"Store '{name}' is not registered.")

--- a/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hasher/__init__.py
+++ b/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hasher/__init__.py
@@ -38,6 +38,8 @@ def __register_hasher(
     name: str, hasher_factory: Callable[..., HasherProtocol]
 ) -> None:
     """Register a hasher class with the given name."""
+    if name in HASHER_REGISTRY:
+        raise ValueError(f"Hasher '{name}' is already registered.")
     HASHER_REGISTRY[name] = hasher_factory
 
 


### PR DESCRIPTION
## Problem

`__register_hasher` and `__register_store` silently overwrote existing entries when the same name was registered twice. This made `factory("sha256")` return whichever implementation was registered last — non-deterministic behavior dependent on import order or registration sequence.

## Fix

Both functions now raise `ValueError` on duplicate registration, turning a silent state mutation into a loud failure.

## Trade-off

Code that intentionally re-registers a name (e.g., for testing or monkey-patching) will now get an error. The existing test suite does not do this, so no test changes are needed.

## Notes

The `HASHER_REGISTRY` and `STORE_FACTORIES` global dicts are otherwise unchanged.
