### PR TITLE
Add LICENSE to each package and fix package-data typo

### DIFF
--- a/packages/kitsuyui-animal/LICENSE
+++ b/packages/kitsuyui-animal/LICENSE
@@ -1,0 +1,11 @@
+Copyright 2023-2025 Kitsu Yui
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/packages/kitsuyui-animal/pyproject.toml
+++ b/packages/kitsuyui-animal/pyproject.toml
@@ -21,7 +21,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
 package-dir = { "" = "src" }
-package-data = { "*" = ["README.md, LICENSE", "py.typed", "*.pyi"] }
+package-data = { "*" = ["README.md", "LICENSE", "py.typed", "*.pyi"] }
 
 [tool.setuptools.packages.find]
 where = ["src/"]

--- a/packages/kitsuyui-content_addr/LICENSE
+++ b/packages/kitsuyui-content_addr/LICENSE
@@ -1,0 +1,11 @@
+Copyright 2023-2025 Kitsu Yui
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/packages/kitsuyui-content_addr/pyproject.toml
+++ b/packages/kitsuyui-content_addr/pyproject.toml
@@ -21,7 +21,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
 package-dir = { "" = "src" }
-package-data = { "*" = ["README.md, LICENSE", "py.typed", "*.pyi"] }
+package-data = { "*" = ["README.md", "LICENSE", "py.typed", "*.pyi"] }
 
 [tool.setuptools.packages.find]
 where = ["src/"]

--- a/packages/kitsuyui-hello/LICENSE
+++ b/packages/kitsuyui-hello/LICENSE
@@ -1,0 +1,11 @@
+Copyright 2023-2025 Kitsu Yui
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/packages/kitsuyui-hello/pyproject.toml
+++ b/packages/kitsuyui-hello/pyproject.toml
@@ -21,7 +21,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
 package-dir = { "" = "src" }
-package-data = { "*" = ["README.md, LICENSE", "py.typed", "*.pyi"] }
+package-data = { "*" = ["README.md", "LICENSE", "py.typed", "*.pyi"] }
 
 [tool.setuptools.packages.find]
 where = ["src/"]


### PR DESCRIPTION
## Problem

### 1. Missing LICENSE files in package directories

All three packages declare `"License :: OSI Approved :: BSD License"` in their classifiers:

- `packages/kitsuyui-hello`
- `packages/kitsuyui-animal`
- `packages/kitsuyui-content_addr`

However, none of them include a `LICENSE` file in the package directory. Wheels and sdists built from these packages will not contain the license text, which is required for proper license compliance.

### 2. Malformed `package-data` entry in `pyproject.toml`

In each package's `pyproject.toml`, the `package-data` field contained:

```toml
package-data = { "*" = ["README.md, LICENSE", ...] }
```

The string `"README.md, LICENSE"` is a single entry with a literal comma — not two separate entries. This means neither `README.md` nor `LICENSE` is matched by the glob pattern and both files are excluded from the built distribution.

## Fix

- Copy the root BSD-3-Clause `LICENSE` file to each of the three package directories.
- Split `"README.md, LICENSE"` into two separate array elements: `"README.md"` and `"LICENSE"`.

## Trade-offs

If the license text changes in the future, each package's copy will need to be updated in sync with the root `LICENSE`. An alternative would be to use a symlink, but symlinks in Python package directories have known cross-platform issues with setuptools and are generally not recommended for distributed packages.
