### PR TITLE
fix(filesystem_store): make clear() remove subdirectories

### DIFF
--- a/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/filesystem_store.py
+++ b/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/filesystem_store.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 import pathlib
+import shutil
 import tempfile
 from typing import cast
 
@@ -146,7 +147,11 @@ class FileSystemStore(BaseStoreProtocol):
         # coordination.
         files = list(self.parent_dir.iterdir())
         for file_path in files:
-            if file_path.is_file() and file_path.name != _METADATA_FILENAME:
+            if file_path.name == _METADATA_FILENAME:
+                continue
+            if file_path.is_dir():
+                shutil.rmtree(file_path)
+            else:
                 file_path.unlink(missing_ok=True)
 
     def destroy(self) -> None:

--- a/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/filesystem_store.py
+++ b/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/filesystem_store.py
@@ -15,6 +15,13 @@ FORMAT_VERSION = 1
 _METADATA_FILENAME = "_metadata.json"
 
 
+def _remove_file_or_directory(file_path: pathlib.Path) -> None:
+    if file_path.is_dir():
+        shutil.rmtree(file_path)
+    else:
+        file_path.unlink(missing_ok=True)
+
+
 class FileSystemStore(BaseStoreProtocol):
     """File-based hash store implementation.
 
@@ -149,10 +156,7 @@ class FileSystemStore(BaseStoreProtocol):
         for file_path in files:
             if file_path.name == _METADATA_FILENAME:
                 continue
-            if file_path.is_dir():
-                shutil.rmtree(file_path)
-            else:
-                file_path.unlink(missing_ok=True)
+            _remove_file_or_directory(file_path)
 
     def destroy(self) -> None:
         self._check_not_destroyed()

--- a/packages/kitsuyui-content_addr/tests/test_hash_store_filesystem_store.py
+++ b/packages/kitsuyui-content_addr/tests/test_hash_store_filesystem_store.py
@@ -105,6 +105,30 @@ def test_filesystem_store_clear_preserves_metadata(temp_dir) -> None:
     assert metadata_path.exists()
 
 
+def test_filesystem_store_clear_with_subdirectory(temp_dir) -> None:
+    store = FileSystemStore(pathlib.Path(temp_dir))
+    metadata_path = pathlib.Path(temp_dir) / _METADATA_FILENAME
+    (pathlib.Path(temp_dir) / "somefile").write_bytes(b"data")
+    subdir = pathlib.Path(temp_dir) / "subdir"
+    subdir.mkdir()
+    (subdir / "nested").write_bytes(b"nested")
+
+    store.clear()
+    assert not (pathlib.Path(temp_dir) / "somefile").exists()
+    assert not subdir.exists()
+    assert metadata_path.exists()
+
+
+def test_filesystem_store_destroy_with_subdirectory(temp_dir) -> None:
+    store = FileSystemStore(pathlib.Path(temp_dir))
+    subdir = pathlib.Path(temp_dir) / "subdir"
+    subdir.mkdir()
+    (subdir / "nested").write_bytes(b"nested")
+
+    store.destroy()
+    assert not pathlib.Path(temp_dir).exists()
+
+
 def test_filesystem_store_destroy_removes_metadata(temp_dir) -> None:
     store = FileSystemStore(pathlib.Path(temp_dir))
     store.destroy()


### PR DESCRIPTION
## Summary

`FileSystemStore.clear()` only called `unlink()` on entries where `is_file()` was `True`, silently skipping subdirectories and directory symlinks. This caused `destroy()` — which calls `clear()` then `rmdir()` — to raise `OSError: [Errno 66] Directory not empty` whenever a subdirectory existed inside the store directory.

- Fix `clear()` to use `shutil.rmtree()` for directory entries, so all content is removed regardless of type.
- Add regression tests covering `clear()` and `destroy()` when a subdirectory is present.

## Changes

- `packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/filesystem_store.py`: import `shutil`; rewrite `clear()` loop to branch on `is_dir()`
- `packages/kitsuyui-content_addr/tests/test_hash_store_filesystem_store.py`: add `test_filesystem_store_clear_with_subdirectory` and `test_filesystem_store_destroy_with_subdirectory`

## Test plan

- `ruff format` and `ruff check` pass with no errors
- `pytest tests` — all 13 tests pass (2 new tests added)
