### PR TITLE
Fix abstract method enforcement in Animal class

### DIFF
--- a/packages/kitsuyui-animal/src/kitsuyui/animal/__init__.py
+++ b/packages/kitsuyui-animal/src/kitsuyui/animal/__init__.py
@@ -19,7 +19,7 @@ import abc
 from ._version import __version__
 
 
-class Animal:
+class Animal(abc.ABC):
     def __init__(self, name: str) -> None:
         self.name = name
 

--- a/packages/kitsuyui-animal/tests/test_basis.py
+++ b/packages/kitsuyui-animal/tests/test_basis.py
@@ -1,7 +1,14 @@
-from kitsuyui.animal import Dog
+import pytest
+
+from kitsuyui.animal import Animal, Dog
 
 
 def test_dog() -> None:
     dog = Dog("Pochi")
     assert dog.name == "Pochi"
     assert dog.speak() == "Bark"
+
+
+def test_animal_is_abstract() -> None:
+    with pytest.raises(TypeError):
+        Animal("test")  # type: ignore[abstract]


### PR DESCRIPTION
## Summary

- `Animal` class now inherits `abc.ABC` so `@abc.abstractmethod` is enforced by Python's ABCMeta mechanism at instantiation time
- Before this change, `Animal("test")` would succeed silently; after, it raises `TypeError` as the abstract contract requires
- Adds `test_animal_is_abstract` to verify direct instantiation raises `TypeError`

## Changes

- `packages/kitsuyui-animal/src/kitsuyui/animal/__init__.py`: `class Animal(abc.ABC)` — one-line fix
- `packages/kitsuyui-animal/tests/test_basis.py`: new test covering the abstract enforcement edge case

## Verification

- `poe check` passes (mypy, ruff, ty — ty warns about `type: ignore[abstract]` being advisory but does not fail)
- `poe test` passes: 2 tests in kitsuyui-animal
