### PR TITLE
Fix store_item to clean up partial file on write failure

### DIFF
--- a/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/filesystem_store.py
+++ b/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/filesystem_store.py
@@ -20,8 +20,14 @@ class FileSystemStore(BaseStoreProtocol):
 
     def store_item(self, hash_value: HashValue, item: RawItem) -> None:
         file_path = self.parent_dir / hash_value.hex()
-        with file_path.open("wb") as f:
-            f.write(item)
+        tmp_path = file_path.with_suffix(".tmp")
+        try:
+            with tmp_path.open("wb") as f:
+                f.write(item)
+            tmp_path.replace(file_path)
+        except BaseException:
+            tmp_path.unlink(missing_ok=True)
+            raise
 
     def stores(self, hash_value: HashValue) -> bool:
         file_path = self.parent_dir / hash_value.hex()

--- a/packages/kitsuyui-content_addr/tests/test_hash_store_filesystem_store.py
+++ b/packages/kitsuyui-content_addr/tests/test_hash_store_filesystem_store.py
@@ -123,12 +123,12 @@ def test_store_item_cleans_up_on_write_failure(temp_dir) -> None:
     import unittest.mock as mock
 
     store = FileSystemStore(pathlib.Path(temp_dir))
-    hash_value = b"hashfail"
+    hash_value = HashValue(b"hashfail")
 
     err = OSError("rename failed")
     patch = mock.patch.object(pathlib.Path, "replace", side_effect=err)
     with patch, pytest.raises(OSError):
-        store.store_item(hash_value, b"data")
+        store.store_item(hash_value, RawItem(b"data"))
 
     assert not store.stores(hash_value)
 

--- a/packages/kitsuyui-content_addr/tests/test_hash_store_filesystem_store.py
+++ b/packages/kitsuyui-content_addr/tests/test_hash_store_filesystem_store.py
@@ -51,3 +51,17 @@ def test_filesystem_store_store_and_retrieve(temp_dir) -> None:
 def test_filesystem_store_factory(temp_dir) -> None:
     store = factory({"repo_dir": temp_dir})
     assert isinstance(store, FileSystemStore)
+
+
+def test_store_item_cleans_up_on_write_failure(temp_dir) -> None:
+    import unittest.mock as mock
+
+    store = FileSystemStore(pathlib.Path(temp_dir))
+    hash_value = b"hashfail"
+
+    err = OSError("rename failed")
+    patch = mock.patch.object(pathlib.Path, "replace", side_effect=err)
+    with patch, pytest.raises(OSError):
+        store.store_item(hash_value, b"data")
+
+    assert not store.stores(hash_value)


### PR DESCRIPTION
## Summary

- `FileSystemStore.store_item()` now writes to a temporary file first, then atomically renames it to the final path
- Before this change, a failed write (e.g., disk full) would leave an empty or partial file under the hash key, causing `stores()` to return `True` while `retrieve()` returned incomplete data
- Adds `test_store_item_cleans_up_on_write_failure` to verify the store invariant holds after write failure

## Changes

- `packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/filesystem_store.py`: atomic write via temp file + `replace()`; cleanup on any exception
- `packages/kitsuyui-content_addr/tests/test_hash_store_filesystem_store.py`: new test that simulates rename failure and asserts the item is absent

## Verification

- `poe check` passes (ruff, mypy, ty)
- `poe test` passes: 12 tests
