### PR TITLE
fix: FileSystemStore.destroy() removes metadata before rmdir

### DIFF
--- a/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/filesystem_store.py
+++ b/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/filesystem_store.py
@@ -57,6 +57,9 @@ class FileSystemStore(BaseStoreProtocol):
 
     def destroy(self) -> None:
         self.clear()
+        metadata_path = self.parent_dir / self.METADATA_FILENAME
+        if metadata_path.exists():
+            metadata_path.unlink()
         self.parent_dir.rmdir()
 
 

--- a/packages/kitsuyui-content_addr/tests/test_hash_store_filesystem_store.py
+++ b/packages/kitsuyui-content_addr/tests/test_hash_store_filesystem_store.py
@@ -85,3 +85,18 @@ def test_filesystem_store_factory_writes_metadata(temp_dir) -> None:
     assert metadata_path.exists()
     metadata = json.loads(metadata_path.read_text())
     assert metadata["hasher"] == "md5"
+
+
+def test_filesystem_store_destroy_with_metadata(temp_dir) -> None:
+    store = FileSystemStore(pathlib.Path(temp_dir), hasher_name="sha256")
+    store.store_item(b"hash1", b"item1")
+    store.destroy()
+    assert not pathlib.Path(temp_dir).exists()
+
+
+def test_filesystem_store_destroy_without_metadata(temp_dir) -> None:
+    store = FileSystemStore(pathlib.Path(temp_dir))
+    store.store_item(b"hash1", b"item1")
+    store.clear()
+    store.destroy()
+    assert not pathlib.Path(temp_dir).exists()


### PR DESCRIPTION
## Summary

- `FileSystemStore.clear()` intentionally skips `_metadata.json`, but `destroy()` calls `clear()` then `rmdir()`, causing `OSError: Directory not empty` when a store was created with `hasher_name`
- Fix: `destroy()` now explicitly removes `_metadata.json` before calling `rmdir()`
- Added tests: `test_filesystem_store_destroy_with_metadata` and `test_filesystem_store_destroy_without_metadata`

## Test plan

- [ ] `uv run poe test` passes (all 8 filesystem store tests pass)
- [ ] `uv run poe check` passes (no type/lint errors)
- [ ] `test_filesystem_store_destroy_with_metadata`: store with `hasher_name="sha256"` → `destroy()` → dir no longer exists
- [ ] `test_filesystem_store_destroy_without_metadata`: store without `hasher_name` → items stored/cleared → `destroy()` → dir no longer exists

Closes: audit-destroy-metadata-not-removed-001