### PR TITLE
Make HashStore immutable with frozen=True

### DIFF
--- a/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/__init__.py
+++ b/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/__init__.py
@@ -15,7 +15,7 @@ VerifyAction = Literal["delete", "error", "ignore"]
 StoreConfig = dict[str, str | None]
 
 
-@dataclass
+@dataclass(frozen=True)
 class HashStore:
     hasher: HasherProtocol
     base_store: BaseStoreProtocol
@@ -100,9 +100,7 @@ class HashStore:
     def _store_raw(self, hash_value: HashValue, item: RawItem) -> None:
         self.base_store.store_item(hash_value, item)
 
-    def _store_overwriting(
-        self, hash_value: HashValue, item: RawItem
-    ) -> None:
+    def _store_overwriting(self, hash_value: HashValue, item: RawItem) -> None:
         self._store_raw(hash_value, item)
 
     def _store_with_error_on_conflict(

--- a/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/base_store.py
+++ b/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/base_store.py
@@ -184,9 +184,7 @@ def register_store_factory(
     return decorator
 
 
-def factory(
-    name: str, *args: object, **kwargs: object
-) -> BaseStoreProtocol:
+def factory(name: str, *args: object, **kwargs: object) -> BaseStoreProtocol:
     """Factory function for creating a store instance by name."""
     if name not in STORE_FACTORIES:
         raise ValueError(f"Store '{name}' is not registered.")


### PR DESCRIPTION
## Why

`HashStore` pairs one `hasher` with one `base_store`.  Items are stored under
keys produced by that hasher, so every object in a store is indexed by the same
algorithm.  Before this change the dataclass was mutable, meaning a caller
could write:

```python
store.hasher = sha256_hasher   # was sha1_hasher at construction
```

This silently breaks the invariant: items already stored under SHA-1 keys
become unreachable because the new hasher produces different keys for the same
content.  There is no error — objects are simply lost.

## What

Add `frozen=True` to the `@dataclass` decorator on `HashStore`.

```python
# before
@dataclass
class HashStore:

# after
@dataclass(frozen=True)
class HashStore:
```

That is the entire functional change.  Attempts to reassign `hasher` or
`base_store` after construction now raise `dataclasses.FrozenInstanceError`
immediately, making the bug impossible at runtime.

The ruff formatter also collapsed two overly-long signatures in `base_store.py`
(no behaviour change).

## Verification

- 11 unit tests pass (`pytest packages/kitsuyui-content_addr/`)
- `mypy` reports no errors
- `ruff check` and `ruff format --check` are clean

## Trade-offs

A frozen dataclass cannot use attribute assignment inside `__post_init__`.
`HashStore` has no `__post_init__`, so this restriction has no practical
impact on the current codebase.
