### PR TITLE
Fix non-deterministic behaviour in FileSystemStore.clear() under concurrent writes

### DIFF
--- a/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/filesystem_store.py
+++ b/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/filesystem_store.py
@@ -117,9 +117,14 @@ class FileSystemStore(BaseStoreProtocol):
         file_path.unlink()
 
     def clear(self) -> None:
-        for file_path in self.parent_dir.iterdir():
+        # Snapshot the listing before iterating so behaviour is deterministic:
+        # files that exist at this point are deleted; files written after the
+        # snapshot are not.  Not safe for concurrent use without external
+        # coordination.
+        files = list(self.parent_dir.iterdir())
+        for file_path in files:
             if file_path.is_file() and file_path.name != _METADATA_FILENAME:
-                file_path.unlink()
+                file_path.unlink(missing_ok=True)
 
     def destroy(self) -> None:
         self.clear()


### PR DESCRIPTION
## Why

`Path.iterdir()` returns a live OS `readdir` stream. If another thread or
process writes a new file into the directory while the iterator is active,
that file may or may not appear in the iteration — the behaviour is
non-deterministic and OS-dependent. Likewise, if a concurrent actor deletes
a file mid-iteration, `unlink()` raises `FileNotFoundError`. As a result,
the invariant "after `clear()` the store is empty" is not guaranteed under
concurrent writers.

## What

- **Snapshot before iterating**: `list(self.parent_dir.iterdir())` is called
  once before the loop. The loop then iterates over the fixed snapshot, making
  the set of files targeted for deletion deterministic: exactly the files
  visible at call time are removed.
- **Tolerate concurrent deletions**: `file_path.unlink(missing_ok=True)` is
  used instead of `file_path.unlink()`, so a `FileNotFoundError` is not raised
  if another process removes the file between the snapshot and the `unlink`
  call.
- **Comment documents the constraint**: a comment in the method body makes
  clear that files written after the snapshot are not deleted, and that `clear()`
  is not safe for concurrent use without external coordination.

## Trade-offs

- Files written to the store **after** the snapshot is taken are not deleted by
  this `clear()` call. Callers that require a stronger guarantee must provide
  external coordination (e.g., a lock) before calling `clear()`.
- No mutex is added; this change does not make `FileSystemStore` concurrency-safe
  in general. It only removes the non-determinism and the crash that existed in
  the previous implementation.

## Verification

- 11 existing tests pass.
- `mypy` and `ruff` report no issues on the changed file.

## Changed files

- `packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/filesystem_store.py`
