### PR TITLE
Validate algorithm name eagerly in generate_hasher()

### DIFF
--- a/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hasher/__init__.py
+++ b/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hasher/__init__.py
@@ -26,6 +26,7 @@ class SHA256Hasher(HasherProtocol):
 def generate_hasher(name: str) -> type[HasherProtocol]:
     if name.lower() in UNSAFE_HASH_ALGORITHMS:
         raise ValueError(f"Unsafe hash algorithm is not supported: {name}")
+    hashlib.new(name)
 
     class CustomHasher(HasherProtocol):
         def compute_hash(self, item: RawItem) -> HashValue:

--- a/packages/kitsuyui-content_addr/tests/test_hasher.py
+++ b/packages/kitsuyui-content_addr/tests/test_hasher.py
@@ -17,3 +17,6 @@ def test_sha256_hasher() -> None:
 def test_generate_hasher_rejects_md5() -> None:
     with pytest.raises(ValueError, match="Unsafe hash algorithm"):
         generate_hasher("md5")
+def test_generate_hasher_invalid_algorithm_raises_at_creation() -> None:
+    with pytest.raises(ValueError):
+        generate_hasher("invalid_algo")


### PR DESCRIPTION
## Why

`generate_hasher(name)` previously deferred `hashlib.new(name)` to the first `compute_hash()` call. This meant a typo like `sha-256` or `SHA256` passed silently at class-registration time and only raised an error when data was first written — at which point partial writes may already have occurred. Eager validation eliminates this silent-failure window.

## What

- **`packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hasher/__init__.py`**: added one `hashlib.new(name)` call at the top of `generate_hasher()`. The result is discarded immediately; the sole purpose is to raise `ValueError` for invalid algorithm names before the inner class is returned.
- **`packages/kitsuyui-content_addr/tests/test_hasher.py`**: added `test_generate_hasher_invalid_algorithm_raises_at_creation` which asserts that `generate_hasher("invalid_algo")` raises `ValueError`.

## Trade-offs

| Concern | Assessment |
|---|---|
| Extra allocation | One `hashlib` object is created and immediately discarded per `generate_hasher()` call. This happens once at class-creation (module load or explicit call), not per hash operation — cost is negligible. |
| Behaviour change | Invalid algorithm names now fail fast at class-creation. This is the desired behaviour and is non-breaking for callers that only pass valid algorithm names. |

## Verification

- 12 tests pass
- `mypy` clean
- `ruff` clean