### PR TITLE
Use PyPI Trusted Publisher (OIDC) for release publishing

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -46,8 +47,6 @@ jobs:
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
         if: github.event_name == 'release' && github.event.release.prerelease
         with:
-          user: __token__
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository-url: https://test.pypi.org/legacy/
           packages-dir: packages/${{ matrix.targets }}/dist
 
@@ -55,6 +54,4 @@ jobs:
         if: github.event_name == 'release' && !github.event.release.prerelease
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
         with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
           packages-dir: packages/${{ matrix.targets }}/dist


### PR DESCRIPTION
## Summary

Migrate PyPI release publishing from legacy API tokens to PyPI Trusted Publisher (OIDC).

- Add `id-token: write` permission to the `deploy` job
- Remove `user: __token__` and `password` (API token secrets) from both PyPI and Test PyPI publish steps
- `pypa/gh-action-pypi-publish` automatically uses OIDC when no `user`/`password` is provided

## Before merging

The following one-time setup is required on PyPI/Test PyPI before this PR can be merged and released:

1. **PyPI**: Add a Trusted Publisher for each package (`kitsuyui-animal`, `kitsuyui-content_addr`, `kitsuyui-hello`)
   - Repository: `kitsuyui/pypi-playground`
   - Workflow: `.github/workflows/pypi-publish.yml`
   - Environment: (none)

2. **Test PyPI**: Same configuration as above on test.pypi.org

After Trusted Publisher is configured, `PYPI_API_TOKEN` and `TEST_PYPI_API_TOKEN` secrets can be removed from the repository settings.

## Trade-offs

Short-lived OIDC tokens are issued per workflow run — no long-lived secrets to rotate or protect.
