### PR TITLE
Import built-in stores in hash_store to register factories on import

### DIFF
--- a/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/__init__.py
+++ b/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/__init__.py
@@ -184,3 +184,8 @@ __all__ = [
     "ConflictAction",
     "HashStore",
 ]
+
+# Trigger @register_store_factory side-effects for built-in stores so that
+# HashStore.create(store_name="dict_store") works without explicit imports.
+from . import dict_store as _dict_store  # noqa: F401, E402
+from . import filesystem_store as _filesystem_store  # noqa: F401, E402


### PR DESCRIPTION
## Summary

Fix implicit dependency on explicit `dict_store`/`filesystem_store` import for `HashStore.create()` to work.

Previously, calling `HashStore.create(store_name="dict_store")` after `from kitsuyui.content_addr import HashStore` would raise `ValueError: Store 'dict_store' is not registered` because `dict_store.py` and `filesystem_store.py` register themselves via `@register_store_factory` only when imported, and neither was imported by the package `__init__.py`.

## Changes

Add side-effect imports to `hash_store/__init__.py` so the built-in store implementations are registered when `HashStore` is imported:

```python
# Trigger @register_store_factory side-effects for built-in stores so that
# HashStore.create(store_name="dict_store") works without explicit imports.
from . import dict_store as _dict_store  # noqa: F401, E402
from . import filesystem_store as _filesystem_store  # noqa: F401, E402
```

## Trade-offs

- Both built-in stores are always imported when `HashStore` is used. This is a minimal overhead (no I/O, pure Python) and matches user expectations from the API surface.
- Custom stores registered via `register_store_factory` are unaffected — third-party callers still need to import their own store modules.
