### PR TITLE
Clean up partial metadata write on FileSystemStore init failure

### DIFF
--- a/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/filesystem_store.py
+++ b/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/filesystem_store.py
@@ -20,8 +20,14 @@ class FileSystemStore(BaseStoreProtocol):
         self.parent_dir.mkdir(parents=True, exist_ok=True)
         if hasher_name is not None:
             metadata_path = self.parent_dir / self.METADATA_FILENAME
-            with metadata_path.open("w") as f:
-                json.dump({"schema_version": 1, "hasher": hasher_name}, f)
+            tmp_path = metadata_path.with_name(metadata_path.name + ".tmp")
+            try:
+                with tmp_path.open("w") as f:
+                    json.dump({"schema_version": 1, "hasher": hasher_name}, f)
+                tmp_path.replace(metadata_path)
+            except Exception:
+                tmp_path.unlink(missing_ok=True)
+                raise
 
     @classmethod
     def create(

--- a/packages/kitsuyui-content_addr/tests/test_hash_store_filesystem_store.py
+++ b/packages/kitsuyui-content_addr/tests/test_hash_store_filesystem_store.py
@@ -85,3 +85,29 @@ def test_filesystem_store_factory_writes_metadata(temp_dir) -> None:
     assert metadata_path.exists()
     metadata = json.loads(metadata_path.read_text())
     assert metadata["hasher"] == "md5"
+
+
+def test_filesystem_store_metadata_cleanup_on_write_failure(
+    temp_dir, monkeypatch
+) -> None:
+    import json as json_module
+
+    original_dump = json_module.dump
+
+    def failing_dump(*_args, **_kwargs):
+        raise OSError("simulated disk full")
+
+    monkeypatch.setattr(json_module, "dump", failing_dump)
+
+    with pytest.raises(OSError, match="simulated disk full"):
+        FileSystemStore(pathlib.Path(temp_dir), hasher_name="sha256")
+
+    metadata_path = pathlib.Path(temp_dir) / FileSystemStore.METADATA_FILENAME
+    tmp_path = metadata_path.with_name(metadata_path.name + ".tmp")
+    assert not metadata_path.exists()
+    assert not tmp_path.exists()
+
+    monkeypatch.setattr(json_module, "dump", original_dump)
+    FileSystemStore(pathlib.Path(temp_dir), hasher_name="sha256")
+    assert metadata_path.exists()
+    assert json.loads(metadata_path.read_text())["hasher"] == "sha256"


### PR DESCRIPTION
## Summary

`FileSystemStore.__init__` introduced a `_metadata.json` write when
`hasher_name` is provided. If the write fails partway (e.g. `OSError` from a
full disk), `open("w")` has already truncated the destination file, leaving a
corrupt or empty `_metadata.json` behind. A subsequent read from the same
directory then fails trying to parse invalid JSON.

This PR switches to a **write-to-temp-then-rename** strategy so the metadata
file is always either fully written or absent.

## Changes

- `filesystem_store.py`: write `_metadata.json.tmp` first, rename
  atomically with `Path.replace()`, and `unlink(missing_ok=True)` the temp
  file in an `except` block if anything fails.
- `tests/test_hash_store_filesystem_store.py`: adds
  `test_filesystem_store_metadata_cleanup_on_write_failure` — patches
  `json.dump` to raise `OSError`, confirms the exception propagates, and
  confirms neither `_metadata.json` nor `_metadata.json.tmp` survives.

## Depends on

This branch is based on `fix/audit-filesystem-store-no-hasher-metadata-001`
(PR #354), which adds the `hasher_name` parameter and the initial metadata
write. The two PRs should be merged in order.

## Verification

- All 16 tests pass: `uv run poe test`
- Lint clean: `uv run poe syntax_check`
- Type check passes: `uv run poe type_check`

## Trade-offs

`Path.replace()` is atomic on POSIX (POSIX `rename(2)`) but is not atomic on
Windows (it calls `MoveFileEx` which is also documented as atomic for files on
the same volume). For the failure scenario handled here — `json.dump` raising
before `replace()` is reached — the behaviour is correct on all platforms.
