### PR TITLE
Add StoreDestroyedError guard to FileSystemStore

### DIFF
--- a/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/exceptions.py
+++ b/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/exceptions.py
@@ -20,3 +20,7 @@ class RetrievalError(HashStoreError, IOError):
 
 class CorruptedItemError(HashStoreError):
     """Raised when a stored item is found to be corrupted."""
+
+
+class StoreDestroyedError(HashStoreError):
+    """Raised when an operation is attempted on a destroyed store."""

--- a/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/filesystem_store.py
+++ b/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/filesystem_store.py
@@ -6,7 +6,7 @@ import pathlib
 import tempfile
 from typing import cast
 
-from ..exceptions import ItemNotFound, RetrievalError
+from ..exceptions import ItemNotFound, RetrievalError, StoreDestroyedError
 from ..types import HashValue, RawItem
 from .base_store import BaseStoreProtocol, register_store_factory
 
@@ -30,6 +30,11 @@ class FileSystemStore(BaseStoreProtocol):
         self.parent_dir = pathlib.Path(parent_dir).resolve()
         self.parent_dir.mkdir(parents=True, exist_ok=True)
         self._init_or_validate_metadata(hasher_algorithm)
+        self._destroyed = False
+
+    def _check_not_destroyed(self) -> None:
+        if self._destroyed:
+            raise StoreDestroyedError("store has been destroyed")
 
     def _metadata_path(self) -> pathlib.Path:
         return self.parent_dir / _METADATA_FILENAME
@@ -97,6 +102,7 @@ class FileSystemStore(BaseStoreProtocol):
         return cls(pathlib.Path(parent_dir), hasher_algorithm=hasher_algorithm)
 
     def store_item(self, hash_value: HashValue, item: RawItem) -> None:
+        self._check_not_destroyed()
         file_path = self.parent_dir / hash_value.hex()
         with tempfile.NamedTemporaryFile(
             dir=self.parent_dir, delete=False, suffix=".tmp"
@@ -108,10 +114,12 @@ class FileSystemStore(BaseStoreProtocol):
         tmp_path.replace(file_path)
 
     def stores(self, hash_value: HashValue) -> bool:
+        self._check_not_destroyed()
         file_path = self.parent_dir / hash_value.hex()
         return file_path.exists()
 
     def retrieve(self, hash_value: HashValue) -> RawItem:
+        self._check_not_destroyed()
         file_path = self.parent_dir / hash_value.hex()
         try:
             with file_path.open("rb") as f:
@@ -126,13 +134,15 @@ class FileSystemStore(BaseStoreProtocol):
             ) from e
 
     def delete(self, hash_value: HashValue) -> None:
+        self._check_not_destroyed()
         file_path = self.parent_dir / hash_value.hex()
         file_path.unlink()
 
     def clear(self) -> None:
+        self._check_not_destroyed()
         # Snapshot the listing before iterating so behaviour is deterministic:
         # files that exist at this point are deleted; files written after the
-        # snapshot are not.  Not safe for concurrent use without external
+        # snapshot are not. Not safe for concurrent use without external
         # coordination.
         files = list(self.parent_dir.iterdir())
         for file_path in files:
@@ -140,9 +150,11 @@ class FileSystemStore(BaseStoreProtocol):
                 file_path.unlink(missing_ok=True)
 
     def destroy(self) -> None:
+        self._check_not_destroyed()
         self.clear()
         self._metadata_path().unlink(missing_ok=True)
         self.parent_dir.rmdir()
+        self._destroyed = True
 
 
 @register_store_factory("filesystem_store")

--- a/packages/kitsuyui-content_addr/tests/test_hash_store_filesystem_store.py
+++ b/packages/kitsuyui-content_addr/tests/test_hash_store_filesystem_store.py
@@ -4,7 +4,7 @@ import tempfile
 
 import pytest
 
-from kitsuyui.content_addr.exceptions import ItemNotFound
+from kitsuyui.content_addr.exceptions import ItemNotFound, StoreDestroyedError
 from kitsuyui.content_addr.hash_store.filesystem_store import (
     _METADATA_FILENAME,
     FORMAT_VERSION,
@@ -48,9 +48,10 @@ def test_filesystem_store_store_and_retrieve(temp_dir) -> None:
     assert not store.stores(hash_value)
     assert not store.stores(hash_value2)
 
-    # destroy store (should be no-op for DictStore)
+    # destroy store removes the backing directory
     store.destroy()
-    assert not store.stores(hash_value)
+    with pytest.raises(StoreDestroyedError):
+        store.stores(hash_value)
 
 
 def test_filesystem_store_factory(temp_dir) -> None:
@@ -161,3 +162,30 @@ def test_filesystem_store_factory_path_is_absolute(temp_dir) -> None:
     store = factory({"repo_dir": temp_dir})
     assert isinstance(store, FileSystemStore)
     assert store.parent_dir.is_absolute()
+
+
+def test_filesystem_store_use_after_destroy_raises(temp_dir) -> None:
+    store = FileSystemStore(pathlib.Path(temp_dir))
+    hash_value = HashValue(b"hash1")
+    store.store_item(hash_value, RawItem(b"data"))
+    store.destroy()
+
+    with pytest.raises(StoreDestroyedError):
+        store.store_item(hash_value, RawItem(b"new"))
+    with pytest.raises(StoreDestroyedError):
+        store.stores(hash_value)
+    with pytest.raises(StoreDestroyedError):
+        store.retrieve(hash_value)
+    with pytest.raises(StoreDestroyedError):
+        store.delete(hash_value)
+    with pytest.raises(StoreDestroyedError):
+        store.clear()
+    with pytest.raises(StoreDestroyedError):
+        store.destroy()
+
+
+def test_filesystem_store_destroy_is_idempotent_error(temp_dir) -> None:
+    store = FileSystemStore(pathlib.Path(temp_dir))
+    store.destroy()
+    with pytest.raises(StoreDestroyedError):
+        store.destroy()


### PR DESCRIPTION
## Summary

- `FileSystemStore.destroy()` removes the backing directory, but the store object had no mechanism to prevent subsequent operations from running against the now-missing directory
- Operations after `destroy()` raised an opaque `FileNotFoundError` rather than a clear domain error
- Added `StoreDestroyedError` (subclass of `HashStoreError`) and a `_destroyed` flag; every public method guards against post-destroy calls

## Changes

- `exceptions.py`: new `StoreDestroyedError(HashStoreError)`
- `filesystem_store.py`: `_destroyed = False` in `__init__`; `_check_not_destroyed()` called at the start of all public methods; `destroy()` sets `_destroyed = True` after removing the directory
- Tests: updated existing destroy test; added `test_filesystem_store_use_after_destroy_raises` (covers all six mutating/reading methods) and `test_filesystem_store_destroy_is_idempotent_error`

## Test plan

- [x] `uv run poe check` passes (ruff + mypy + ty)
- [x] `uv run poe test` passes (13 tests)
- [x] All six post-destroy operations raise `StoreDestroyedError`
- [x] Calling `destroy()` a second time raises `StoreDestroyedError`

## Trade-offs

The guard lives only in `FileSystemStore`; `BaseStoreProtocol` (a `Protocol`) is unchanged. Other store implementations are not affected. If a cross-store destroyed-state contract is needed in the future, adding `is_destroyed` to the protocol would be the natural next step.
