### PR TITLE
Configure dependabot for github-actions and uv ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,10 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "uv"
+    directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
## Summary

- `.github/dependabot.yml` had `package-ecosystem: ""` (template placeholder never filled in), so Dependabot version updates were not running
- Replace the invalid empty-string entry with two valid entries: `github-actions` and `uv`

## Changes

- `.github/dependabot.yml`: remove the placeholder entry; add `github-actions` (for workflow action pins) and `uv` (for the uv workspace at `/`) with weekly schedules

## Test plan

- [x] YAML is valid (no syntax errors)
- [x] `uv run poe check` passes
- [x] `uv run poe test` passes
- [x] Dependabot will now create weekly update PRs for GitHub Actions and Python (uv) dependencies
