### PR TITLE
Delegate store_if_not_exists and store_or_raise to store()

### DIFF
--- a/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/__init__.py
+++ b/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/__init__.py
@@ -100,9 +100,7 @@ class HashStore:
     def _store_raw(self, hash_value: HashValue, item: RawItem) -> None:
         self.base_store.store_item(hash_value, item)
 
-    def _store_overwriting(
-        self, hash_value: HashValue, item: RawItem
-    ) -> None:
+    def _store_overwriting(self, hash_value: HashValue, item: RawItem) -> None:
         self._store_raw(hash_value, item)
 
     def _store_with_error_on_conflict(
@@ -150,21 +148,18 @@ class HashStore:
         return hash_value
 
     def store_if_not_exists(self, item: RawItem) -> HashValue:
-        """Store the item only if it does not already exist."""
-        hash_value = self.compute_hash(item)
-        if not self.stores(hash_value):
-            self._store_raw(hash_value, item)
-        return hash_value
+        """Store the item only if it does not already exist.
+
+        Equivalent to store(item, conflicts="ignore").
+        """
+        return self.store(item, conflicts="ignore")
 
     def store_or_raise(self, item: RawItem) -> HashValue:
-        """Store the item, raising ItemAlreadyExists if it already exists."""
-        hash_value = self.compute_hash(item)
-        if self.stores(hash_value):
-            raise ItemAlreadyExists(
-                f"Item with hash {hash_value.hex()} already exists."
-            )
-        self._store_raw(hash_value, item)
-        return hash_value
+        """Store the item, raising ItemAlreadyExists if it already exists.
+
+        Equivalent to store(item, conflicts="error").
+        """
+        return self.store(item, conflicts="error")
 
 
 def factory(

--- a/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/base_store.py
+++ b/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/base_store.py
@@ -184,9 +184,7 @@ def register_store_factory(
     return decorator
 
 
-def factory(
-    name: str, *args: object, **kwargs: object
-) -> BaseStoreProtocol:
+def factory(name: str, *args: object, **kwargs: object) -> BaseStoreProtocol:
     """Factory function for creating a store instance by name."""
     if name not in STORE_FACTORIES:
         raise ValueError(f"Store '{name}' is not registered.")

--- a/packages/kitsuyui-content_addr/tests/test_hash_store.py
+++ b/packages/kitsuyui-content_addr/tests/test_hash_store.py
@@ -56,6 +56,28 @@ def test_hash_store() -> None:
     assert not store.stores(hash_value)
 
 
+def test_store_if_not_exists() -> None:
+    """store_if_not_exists is equivalent to store(conflicts="ignore")."""
+    store = HashStore(hasher=SHA256Hasher(), base_store=DictStore())
+    item = b"alias ignore item"
+    hash_value = store.store_if_not_exists(item)
+    assert store.stores(hash_value)
+    # Second call must not raise and must return the same hash.
+    hash_value2 = store.store_if_not_exists(item)
+    assert hash_value == hash_value2
+
+
+def test_store_or_raise() -> None:
+    """store_or_raise is equivalent to store(conflicts="error")."""
+    store = HashStore(hasher=SHA256Hasher(), base_store=DictStore())
+    item = b"alias error item"
+    hash_value = store.store_or_raise(item)
+    assert store.stores(hash_value)
+    # Second call must raise ItemAlreadyExists.
+    with pytest.raises(ItemAlreadyExists):
+        store.store_or_raise(item)
+
+
 def test_hash_store_factory() -> None:
     store = factory(
         hasher_name="sha256",


### PR DESCRIPTION
## Summary

`HashStore` exposed two methods that duplicated the conflict-handling logic
already implemented inside `store(conflicts=...)`:

- `store_if_not_exists(item)` — same behaviour as `store(item, conflicts="ignore")`
- `store_or_raise(item)` — same behaviour as `store(item, conflicts="error")`

Neither method was covered by tests, so a future change to `store()` or its
`_store_ignoring_conflicts` / `_store_with_error_on_conflict` helpers could cause
silent divergence without any failing assertions.

## Change

Replace each method body with a single-line delegation to `store()`, and update
docstrings to make the equivalence explicit:

```python
def store_if_not_exists(self, item: RawItem) -> HashValue:
    """... Equivalent to store(item, conflicts="ignore"). """
    return self.store(item, conflicts="ignore")

def store_or_raise(self, item: RawItem) -> HashValue:
    """... Equivalent to store(item, conflicts="error"). """
    return self.store(item, conflicts="error")
```

## Tests

Added `test_store_if_not_exists` and `test_store_or_raise` verifying:
- First call stores the item and returns the correct hash
- `store_if_not_exists` silently accepts a duplicate (no exception)
- `store_or_raise` raises `ItemAlreadyExists` on a duplicate

## Verification

```
$ uv run poe test
13 passed

$ uv run poe check
All checks passed!
```

## Trade-offs

The API surface (`store_if_not_exists`, `store_or_raise`) is preserved unchanged.
Callers do not need to migrate. The delegation adds one extra frame on the call
stack, which is negligible for I/O-bound storage operations.
