### PR TITLE
Fix store_item protocol docstrings

### DIFF
--- a/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/__init__.py
+++ b/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/__init__.py
@@ -100,9 +100,7 @@ class HashStore:
     def _store_raw(self, hash_value: HashValue, item: RawItem) -> None:
         self.base_store.store_item(hash_value, item)
 
-    def _store_overwriting(
-        self, hash_value: HashValue, item: RawItem
-    ) -> None:
+    def _store_overwriting(self, hash_value: HashValue, item: RawItem) -> None:
         self._store_raw(hash_value, item)
 
     def _store_with_error_on_conflict(

--- a/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/base_store.py
+++ b/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/base_store.py
@@ -18,7 +18,7 @@ class BaseStoreProtocol(Protocol):
     """
 
     def store_item(self, hash_value: HashValue, item: RawItem) -> None:
-        """Store the given item and return its hash value."""
+        """Store the given item for the supplied hash value."""
 
     def stores(self, hash_value: HashValue) -> bool:
         """Return whether the item with the given hash value is stored."""
@@ -45,7 +45,7 @@ class AsyncBaseStoreProtocol(Protocol):
     """
 
     async def store_item(self, hash_value: HashValue, item: RawItem) -> None:
-        """Store the given item and return its hash value."""
+        """Store the given item for the supplied hash value."""
 
     async def stores(self, hash_value: HashValue) -> bool:
         """Return whether the item with the given hash value is stored."""
@@ -184,9 +184,7 @@ def register_store_factory(
     return decorator
 
 
-def factory(
-    name: str, *args: object, **kwargs: object
-) -> BaseStoreProtocol:
+def factory(name: str, *args: object, **kwargs: object) -> BaseStoreProtocol:
     """Factory function for creating a store instance by name."""
     if name not in STORE_FACTORIES:
         raise ValueError(f"Store '{name}' is not registered.")


### PR DESCRIPTION
## Summary
- Update the sync and async `store_item` protocol docstrings so they describe storing an item for an existing hash value.
- Keep the hash-returning wording limited to `HashStore.store()`, which computes and returns the hash value.
- Apply the repository formatter to the touched `hash_store` module.

## Validation
- `uv sync && uv run poe sync-all`
- `uv run poe format`
- `uv run poe check`
- `uv run poe test`
- `uv run poe coverage`
- `uv run poe build`
- `uv run ruff check src tests --config ../dev-shared/ruff.toml --statistics` from `packages/kitsuyui-content_addr`
- `git diff --check`

## Trade-offs
- This is a documentation-only contract fix; it does not change runtime behavior.
