### PR TITLE
fix: use NewType for HashValue and RawItem to prevent silent argument swap

### DIFF
--- a/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/__init__.py
+++ b/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/__init__.py
@@ -100,9 +100,7 @@ class HashStore:
     def _store_raw(self, hash_value: HashValue, item: RawItem) -> None:
         self.base_store.store_item(hash_value, item)
 
-    def _store_overwriting(
-        self, hash_value: HashValue, item: RawItem
-    ) -> None:
+    def _store_overwriting(self, hash_value: HashValue, item: RawItem) -> None:
         self._store_raw(hash_value, item)
 
     def _store_with_error_on_conflict(

--- a/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/base_store.py
+++ b/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/base_store.py
@@ -184,9 +184,7 @@ def register_store_factory(
     return decorator
 
 
-def factory(
-    name: str, *args: object, **kwargs: object
-) -> BaseStoreProtocol:
+def factory(name: str, *args: object, **kwargs: object) -> BaseStoreProtocol:
     """Factory function for creating a store instance by name."""
     if name not in STORE_FACTORIES:
         raise ValueError(f"Store '{name}' is not registered.")

--- a/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/dict_store.py
+++ b/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/dict_store.py
@@ -8,7 +8,7 @@ class DictStore(BaseStoreProtocol):
     """
 
     def __init__(self) -> None:
-        self._store: dict[bytes, bytes] = {}
+        self._store: dict[HashValue, RawItem] = {}
 
     def store_item(self, hash_value: HashValue, item: RawItem) -> None:
         self._store[hash_value] = item

--- a/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/filesystem_store.py
+++ b/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/filesystem_store.py
@@ -30,7 +30,7 @@ class FileSystemStore(BaseStoreProtocol):
     def retrieve(self, hash_value: HashValue) -> RawItem:
         file_path = self.parent_dir / hash_value.hex()
         with file_path.open("rb") as f:
-            return f.read()
+            return RawItem(f.read())
 
     def delete(self, hash_value: HashValue) -> None:
         file_path = self.parent_dir / hash_value.hex()

--- a/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hasher/__init__.py
+++ b/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hasher/__init__.py
@@ -26,7 +26,7 @@ def generate_hasher(name: str) -> type[HasherProtocol]:
         def compute_hash(self, item: RawItem) -> HashValue:
             raw_hasher = hashlib.new(name)
             raw_hasher.update(item)
-            return raw_hasher.digest()
+            return HashValue(raw_hasher.digest())
 
     return CustomHasher
 

--- a/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/types.py
+++ b/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/types.py
@@ -1,2 +1,4 @@
-RawItem = bytes
-HashValue = bytes
+from typing import NewType
+
+RawItem = NewType("RawItem", bytes)
+HashValue = NewType("HashValue", bytes)

--- a/packages/kitsuyui-content_addr/tests/test_hash_store.py
+++ b/packages/kitsuyui-content_addr/tests/test_hash_store.py
@@ -6,11 +6,12 @@ from kitsuyui.content_addr.exceptions import ItemAlreadyExists
 from kitsuyui.content_addr.hash_store import HashStore, factory
 from kitsuyui.content_addr.hash_store.dict_store import DictStore
 from kitsuyui.content_addr.hasher import SHA256Hasher
+from kitsuyui.content_addr.types import RawItem
 
 
 def test_example_usage() -> None:
     store = HashStore.create(hasher_name="sha256", store_name="dict_store")
-    item = b"example item"
+    item = RawItem(b"example item")
     hash_value = store.store(item)
     assert store.stores(hash_value)
     retrieved_item = store.retrieve(hash_value)
@@ -19,7 +20,7 @@ def test_example_usage() -> None:
 
 def test_hash_store() -> None:
     store = HashStore(hasher=SHA256Hasher(), base_store=DictStore())
-    item = b"test item"
+    item = RawItem(b"test item")
     hash_value = store.store(item)
     assert store.stores(hash_value)
     retrieved_item = store.retrieve(hash_value)
@@ -39,7 +40,7 @@ def test_hash_store() -> None:
     assert store.verify(hash_value, action="ignore")
 
     # break the item in the store to test validation failure
-    store._store_raw(hash_value, b"corrupted item")
+    store._store_raw(hash_value, RawItem(b"corrupted item"))
     assert not store.verify(hash_value, action="ignore")
     with pytest.raises(ValueError):
         store.verify(hash_value, action="error")
@@ -51,7 +52,7 @@ def test_hash_store() -> None:
     assert store.verify(hash_value, action="ignore")
 
     # break the item again and test delete action
-    store._store_raw(hash_value, b"corrupted item")
+    store._store_raw(hash_value, RawItem(b"corrupted item"))
     store.verify(hash_value, action="delete")
     assert not store.stores(hash_value)
 
@@ -64,7 +65,7 @@ def test_hash_store_factory() -> None:
     assert isinstance(store.base_store, DictStore)
     assert isinstance(store.hasher, SHA256Hasher)
 
-    item = b"another test item"
+    item = RawItem(b"another test item")
     hash_value = store.store(item)
     assert store.stores(hash_value)
 

--- a/packages/kitsuyui-content_addr/tests/test_hash_store_async_dict_store.py
+++ b/packages/kitsuyui-content_addr/tests/test_hash_store_async_dict_store.py
@@ -4,13 +4,14 @@ from kitsuyui.content_addr.hash_store.async_dict_store import AsyncDictStore
 from kitsuyui.content_addr.hash_store.base_store import (
     wrap_async_store_as_sync,
 )
+from kitsuyui.content_addr.types import HashValue, RawItem
 
 
 def test_async_dict_store_store_and_retrieve() -> None:
     DictStore2 = wrap_async_store_as_sync("DictStore2", AsyncDictStore)
     store = DictStore2()
-    hash_value = b"hash1"
-    item = b"item1"
+    hash_value = HashValue(b"hash1")
+    item = RawItem(b"item1")
 
     store.store_item(hash_value, item)
     assert store.stores(hash_value)
@@ -18,8 +19,8 @@ def test_async_dict_store_store_and_retrieve() -> None:
     assert retrieved_item == item
 
     # second item
-    hash_value2 = b"hash2"
-    item2 = b"item2"
+    hash_value2 = HashValue(b"hash2")
+    item2 = RawItem(b"item2")
     store.store_item(hash_value2, item2)
     assert store.stores(hash_value2)
     retrieved_item2 = store.retrieve(hash_value2)
@@ -43,8 +44,8 @@ def test_async_dict_store_store_and_retrieve() -> None:
 async def _store_and_retrieve_inside_running_loop() -> None:
     DictStore2 = wrap_async_store_as_sync("DictStore2", AsyncDictStore)
     store = DictStore2()
-    hash_value = b"hash1"
-    item = b"item1"
+    hash_value = HashValue(b"hash1")
+    item = RawItem(b"item1")
 
     store.store_item(hash_value, item)
 

--- a/packages/kitsuyui-content_addr/tests/test_hash_store_dict_store.py
+++ b/packages/kitsuyui-content_addr/tests/test_hash_store_dict_store.py
@@ -1,10 +1,11 @@
 from kitsuyui.content_addr.hash_store.dict_store import DictStore, factory
+from kitsuyui.content_addr.types import HashValue, RawItem
 
 
 def test_dict_store_store_and_retrieve() -> None:
     store = DictStore()
-    hash_value = b"hash1"
-    item = b"item1"
+    hash_value = HashValue(b"hash1")
+    item = RawItem(b"item1")
 
     store.store_item(hash_value, item)
     assert store.stores(hash_value)
@@ -12,8 +13,8 @@ def test_dict_store_store_and_retrieve() -> None:
     assert retrieved_item == item
 
     # second item
-    hash_value2 = b"hash2"
-    item2 = b"item2"
+    hash_value2 = HashValue(b"hash2")
+    item2 = RawItem(b"item2")
     store.store_item(hash_value2, item2)
     assert store.stores(hash_value2)
     retrieved_item2 = store.retrieve(hash_value2)

--- a/packages/kitsuyui-content_addr/tests/test_hash_store_filesystem_store.py
+++ b/packages/kitsuyui-content_addr/tests/test_hash_store_filesystem_store.py
@@ -7,6 +7,7 @@ from kitsuyui.content_addr.hash_store.filesystem_store import (
     FileSystemStore,
     factory,
 )
+from kitsuyui.content_addr.types import HashValue, RawItem
 
 
 @pytest.fixture(scope="function", autouse=True)
@@ -17,8 +18,8 @@ def temp_dir():
 
 def test_filesystem_store_store_and_retrieve(temp_dir) -> None:
     store = FileSystemStore(pathlib.Path(temp_dir))
-    hash_value = b"hash1"
-    item = b"item1"
+    hash_value = HashValue(b"hash1")
+    item = RawItem(b"item1")
 
     store.store_item(hash_value, item)
     assert store.stores(hash_value)
@@ -26,8 +27,8 @@ def test_filesystem_store_store_and_retrieve(temp_dir) -> None:
     assert retrieved_item == item
 
     # second item
-    hash_value2 = b"hash2"
-    item2 = b"item2"
+    hash_value2 = HashValue(b"hash2")
+    item2 = RawItem(b"item2")
     store.store_item(hash_value2, item2)
     assert store.stores(hash_value2)
     retrieved_item2 = store.retrieve(hash_value2)

--- a/packages/kitsuyui-content_addr/tests/test_hasher.py
+++ b/packages/kitsuyui-content_addr/tests/test_hasher.py
@@ -1,9 +1,10 @@
 from kitsuyui.content_addr.hasher import MD5Hasher, SHA256Hasher
+from kitsuyui.content_addr.types import RawItem
 
 
 def test_sha256_hasher() -> None:
     hasher = SHA256Hasher()
-    item = b"Hello, World!"
+    item = RawItem(b"Hello, World!")
     expected_hash_hex = (
         "dffd6021bb2bd5b0af676290809ec3a53191dd81c7f70a4b28688a362182986f"
     )
@@ -13,7 +14,7 @@ def test_sha256_hasher() -> None:
 
 def test_md5_hasher() -> None:
     hasher = MD5Hasher()
-    item = b"Hello, World!"
+    item = RawItem(b"Hello, World!")
     expected_hash_hex = "65a8e27d8879283831b664bd8b7f0ad4"
     computed_hash = hasher.compute_hash(item)
     assert computed_hash.hex() == expected_hash_hex


### PR DESCRIPTION
## Summary

`HashValue` and `RawItem` in `types.py` were plain `bytes` type aliases, making them
structurally identical. A caller could silently swap the arguments to `store_item(hash_value, item)`
and neither mypy nor the runtime would detect it, leading to silent data corruption.

This PR changes both to `NewType`, making them distinct types for static analysis while
remaining transparent at runtime.

## Changes

- `types.py` — replace simple aliases with `NewType("HashValue", bytes)` and `NewType("RawItem", bytes)`
- `hasher/__init__.py` — cast `raw_hasher.digest()` to `HashValue` at the return site
- `hash_store/filesystem_store.py` — cast `f.read()` to `RawItem` at the return site
- `hash_store/dict_store.py` — update `_store` annotation to `dict[HashValue, RawItem]`
- Tests — wrap `bytes` literals with `HashValue(...)` / `RawItem(...)` so tests model correct usage

## Verification

- `ruff check`: all checks passed
- `mypy`: no issues found in 16 source files
- `ty check`: all checks passed
- `pytest`: 11 passed

## Trade-offs

`NewType` constructors (`HashValue(b"...")`) add minor verbosity at call sites. The benefit is
that mypy and ty can now detect `store_item(item, hash_value)` argument-order mistakes at
static analysis time.
