### PR TITLE
Resolve parent_dir to an absolute path in FileSystemStore.__init__

### DIFF
--- a/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/filesystem_store.py
+++ b/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/filesystem_store.py
@@ -20,7 +20,7 @@ class FileSystemStore(BaseStoreProtocol):
         parent_dir: pathlib.Path,
         hasher_algorithm: str | None = None,
     ) -> None:
-        self.parent_dir = pathlib.Path(parent_dir)
+        self.parent_dir = pathlib.Path(parent_dir).resolve()
         self.parent_dir.mkdir(parents=True, exist_ok=True)
         self._init_or_validate_metadata(hasher_algorithm)
 

--- a/packages/kitsuyui-content_addr/tests/test_hash_store_filesystem_store.py
+++ b/packages/kitsuyui-content_addr/tests/test_hash_store_filesystem_store.py
@@ -126,3 +126,24 @@ def test_filesystem_store_retrieve_missing_raises_item_not_found(
     missing_hash = HashValue(b"does_not_exist")
     with pytest.raises(ItemNotFound):
         store.retrieve(missing_hash)
+
+
+def test_filesystem_store_parent_dir_is_absolute(temp_dir) -> None:
+    store = FileSystemStore(pathlib.Path(temp_dir))
+    assert store.parent_dir.is_absolute()
+
+
+def test_filesystem_store_resolves_relative_traversal(temp_dir) -> None:
+    # A path containing ".." components is resolved to an absolute path,
+    # preventing traversal outside the intended root at mkdir time.
+    subdir = pathlib.Path(temp_dir) / "sub"
+    subdir.mkdir()
+    traversal = subdir / ".." / "sub"
+    store = FileSystemStore(traversal)
+    assert store.parent_dir == subdir.resolve()
+
+
+def test_filesystem_store_factory_path_is_absolute(temp_dir) -> None:
+    store = factory({"repo_dir": temp_dir})
+    assert isinstance(store, FileSystemStore)
+    assert store.parent_dir.is_absolute()


### PR DESCRIPTION
## Summary

`FileSystemStore.__init__` stored `parent_dir` as-is, so a value like
`../../sensitive` passed through `factory()` would be used verbatim in
`mkdir(parents=True)`, potentially placing the store root outside the
caller's intended directory.

## Change

One-line fix: call `.resolve()` when assigning `self.parent_dir` so the
path is always absolute and `..` components are collapsed before the
first filesystem operation.

```python
# before
self.parent_dir = pathlib.Path(parent_dir)

# after
self.parent_dir = pathlib.Path(parent_dir).resolve()
```

The fix is in `__init__` rather than only in `factory()` so the
invariant holds regardless of how the store is constructed
(`FileSystemStore(...)`, `FileSystemStore.create(...)`, or `factory(...)`).

## Tests added

- `test_filesystem_store_parent_dir_is_absolute`: `parent_dir` is always
  absolute after construction.
- `test_filesystem_store_resolves_relative_traversal`: a path with `..`
  components is collapsed to its canonical form.
- `test_filesystem_store_factory_path_is_absolute`: the same guarantee
  holds when the store is created via `factory()`.

## Verification

- `uv run poe test`: 14/14 passed (3 new, 11 existing)
- `uv run poe check` (ruff + mypy + ty): no issues
