### PR TITLE
feat(content_addr): record format version and hasher algorithm in FileSystemStore

### DIFF
--- a/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/__init__.py
+++ b/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/__init__.py
@@ -100,9 +100,7 @@ class HashStore:
     def _store_raw(self, hash_value: HashValue, item: RawItem) -> None:
         self.base_store.store_item(hash_value, item)
 
-    def _store_overwriting(
-        self, hash_value: HashValue, item: RawItem
-    ) -> None:
+    def _store_overwriting(self, hash_value: HashValue, item: RawItem) -> None:
         self._store_raw(hash_value, item)
 
     def _store_with_error_on_conflict(

--- a/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/base_store.py
+++ b/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/base_store.py
@@ -184,9 +184,7 @@ def register_store_factory(
     return decorator
 
 
-def factory(
-    name: str, *args: object, **kwargs: object
-) -> BaseStoreProtocol:
+def factory(name: str, *args: object, **kwargs: object) -> BaseStoreProtocol:
     """Factory function for creating a store instance by name."""
     if name not in STORE_FACTORIES:
         raise ValueError(f"Store '{name}' is not registered.")

--- a/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/filesystem_store.py
+++ b/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/filesystem_store.py
@@ -1,22 +1,92 @@
 from __future__ import annotations
 
+import json
 import pathlib
 from typing import cast
 
 from ..types import HashValue, RawItem
 from .base_store import BaseStoreProtocol, register_store_factory
 
+FORMAT_VERSION = 1
+_METADATA_FILENAME = "_metadata.json"
+
 
 class FileSystemStore(BaseStoreProtocol):
     """File-based hash store implementation."""
 
-    def __init__(self, parent_dir: pathlib.Path) -> None:
+    def __init__(
+        self,
+        parent_dir: pathlib.Path,
+        hasher_algorithm: str | None = None,
+    ) -> None:
         self.parent_dir = pathlib.Path(parent_dir)
         self.parent_dir.mkdir(parents=True, exist_ok=True)
+        self._init_or_validate_metadata(hasher_algorithm)
+
+    def _metadata_path(self) -> pathlib.Path:
+        return self.parent_dir / _METADATA_FILENAME
+
+    def _load_metadata(self) -> dict[str, object]:
+        try:
+            with self._metadata_path().open("r") as f:
+                return cast(dict[str, object], json.load(f))
+        except (json.JSONDecodeError, OSError) as e:
+            raise ValueError(f"Failed to read store metadata: {e}") from e
+
+    def _check_algorithm_conflict(
+        self, stored: object, hasher_algorithm: str | None
+    ) -> None:
+        if (
+            not isinstance(stored, str)
+            or hasher_algorithm is None
+            or stored == hasher_algorithm
+        ):
+            return
+        raise ValueError(
+            f"Hasher algorithm mismatch: store was created with "
+            f"'{stored}', but '{hasher_algorithm}' was requested."
+        )
+
+    def _validate_existing(
+        self,
+        metadata: dict[str, object],
+        hasher_algorithm: str | None,
+    ) -> None:
+        if metadata.get("format_version") != FORMAT_VERSION:
+            raise ValueError(
+                f"Incompatible format version: "
+                f"{metadata.get('format_version')!r}. "
+                f"Expected {FORMAT_VERSION}."
+            )
+        self._check_algorithm_conflict(
+            metadata.get("hasher_algorithm"), hasher_algorithm
+        )
+
+    def _write_metadata(self, hasher_algorithm: str | None) -> None:
+        metadata_path = self._metadata_path()
+        new_metadata: dict[str, object] = {"format_version": FORMAT_VERSION}
+        if hasher_algorithm is not None:
+            new_metadata["hasher_algorithm"] = hasher_algorithm
+        try:
+            with metadata_path.open("w") as f:
+                json.dump(new_metadata, f)
+        except OSError as e:
+            metadata_path.unlink(missing_ok=True)
+            raise ValueError(f"Failed to write store metadata: {e}") from e
+
+    def _init_or_validate_metadata(self, hasher_algorithm: str | None) -> None:
+        if self._metadata_path().exists():
+            self._validate_existing(self._load_metadata(), hasher_algorithm)
+        else:
+            self._write_metadata(hasher_algorithm)
 
     @classmethod
-    def create(cls, parent_dir: pathlib.Path | str) -> FileSystemStore:
-        return cls(pathlib.Path(parent_dir))
+    def create(
+        cls,
+        parent_dir: pathlib.Path | str,
+        hasher_algorithm: str | None = None,
+    ) -> FileSystemStore:
+        return cls(pathlib.Path(parent_dir), hasher_algorithm=hasher_algorithm)
 
     def store_item(self, hash_value: HashValue, item: RawItem) -> None:
         file_path = self.parent_dir / hash_value.hex()
@@ -38,11 +108,12 @@ class FileSystemStore(BaseStoreProtocol):
 
     def clear(self) -> None:
         for file_path in self.parent_dir.iterdir():
-            if file_path.is_file():
+            if file_path.is_file() and file_path.name != _METADATA_FILENAME:
                 file_path.unlink()
 
     def destroy(self) -> None:
         self.clear()
+        self._metadata_path().unlink(missing_ok=True)
         self.parent_dir.rmdir()
 
 
@@ -60,4 +131,5 @@ def factory(config: object | None = None) -> BaseStoreProtocol:
     if not isinstance(repo_dir, (str, pathlib.Path)):
         raise ValueError(f"{repo_key} must be a string or pathlib.Path")
 
-    return FileSystemStore.create(repo_dir)
+    hasher_algorithm = cast(str | None, typed_config.get("hasher_algorithm"))
+    return FileSystemStore.create(repo_dir, hasher_algorithm=hasher_algorithm)

--- a/packages/kitsuyui-content_addr/tests/test_hash_store_filesystem_store.py
+++ b/packages/kitsuyui-content_addr/tests/test_hash_store_filesystem_store.py
@@ -1,9 +1,12 @@
+import json
 import pathlib
 import tempfile
 
 import pytest
 
 from kitsuyui.content_addr.hash_store.filesystem_store import (
+    _METADATA_FILENAME,
+    FORMAT_VERSION,
     FileSystemStore,
     factory,
 )
@@ -51,3 +54,64 @@ def test_filesystem_store_store_and_retrieve(temp_dir) -> None:
 def test_filesystem_store_factory(temp_dir) -> None:
     store = factory({"repo_dir": temp_dir})
     assert isinstance(store, FileSystemStore)
+
+
+def test_filesystem_store_creates_metadata(temp_dir) -> None:
+    FileSystemStore(pathlib.Path(temp_dir))
+    metadata_path = pathlib.Path(temp_dir) / _METADATA_FILENAME
+    assert metadata_path.exists()
+    with metadata_path.open() as f:
+        metadata = json.load(f)
+    assert metadata["format_version"] == FORMAT_VERSION
+
+
+def test_filesystem_store_records_hasher_algorithm(temp_dir) -> None:
+    FileSystemStore(pathlib.Path(temp_dir), hasher_algorithm="sha256")
+    metadata_path = pathlib.Path(temp_dir) / _METADATA_FILENAME
+    with metadata_path.open() as f:
+        metadata = json.load(f)
+    assert metadata["hasher_algorithm"] == "sha256"
+
+
+def test_filesystem_store_algorithm_mismatch_raises(temp_dir) -> None:
+    FileSystemStore(pathlib.Path(temp_dir), hasher_algorithm="sha256")
+    with pytest.raises(ValueError, match="algorithm mismatch"):
+        FileSystemStore(pathlib.Path(temp_dir), hasher_algorithm="sha3_256")
+
+
+def test_filesystem_store_no_algorithm_on_reopen_ok(temp_dir) -> None:
+    FileSystemStore(pathlib.Path(temp_dir), hasher_algorithm="sha256")
+    # reopening without specifying algorithm is allowed
+    store = FileSystemStore(pathlib.Path(temp_dir))
+    assert isinstance(store, FileSystemStore)
+
+
+def test_filesystem_store_format_version_mismatch_raises(temp_dir) -> None:
+    metadata_path = pathlib.Path(temp_dir) / _METADATA_FILENAME
+    with metadata_path.open("w") as f:
+        json.dump({"format_version": 999}, f)
+    with pytest.raises(ValueError, match="Incompatible format version"):
+        FileSystemStore(pathlib.Path(temp_dir))
+
+
+def test_filesystem_store_clear_preserves_metadata(temp_dir) -> None:
+    store = FileSystemStore(pathlib.Path(temp_dir))
+    store.store_item(b"hash1", b"item1")
+    store.clear()
+    metadata_path = pathlib.Path(temp_dir) / _METADATA_FILENAME
+    assert metadata_path.exists()
+
+
+def test_filesystem_store_destroy_removes_metadata(temp_dir) -> None:
+    store = FileSystemStore(pathlib.Path(temp_dir))
+    store.destroy()
+    assert not pathlib.Path(temp_dir).exists()
+
+
+def test_filesystem_store_factory_with_hasher_algorithm(temp_dir) -> None:
+    store = factory({"repo_dir": temp_dir, "hasher_algorithm": "sha256"})
+    assert isinstance(store, FileSystemStore)
+    metadata_path = pathlib.Path(temp_dir) / _METADATA_FILENAME
+    with metadata_path.open() as f:
+        metadata = json.load(f)
+    assert metadata["hasher_algorithm"] == "sha256"


### PR DESCRIPTION
## Summary

- `FileSystemStore` now writes a `_metadata.json` file on first use, recording `format_version` and (optionally) the `hasher_algorithm` passed via config.
- On subsequent opens, the format version is validated and algorithm mismatches are detected with a clear error message.
- `clear()` preserves the metadata file; `destroy()` removes it before `rmdir`.
- The `filesystem_store` factory accepts an optional `hasher_algorithm` config key.

## Motivation

Previously, items were stored with filename = hash hex, but no metadata recorded which algorithm produced those hashes. Switching from `sha256` to `sha3_256` silently made all cached items inaccessible, with no way to detect or diagnose the mismatch.

## Test plan

- [ ] `test_filesystem_store_creates_metadata`: metadata file created on first init
- [ ] `test_filesystem_store_records_hasher_algorithm`: algorithm recorded when passed
- [ ] `test_filesystem_store_algorithm_mismatch_raises`: ValueError on algorithm mismatch
- [ ] `test_filesystem_store_no_algorithm_on_reopen_ok`: reopening without algorithm is allowed
- [ ] `test_filesystem_store_format_version_mismatch_raises`: ValueError on version mismatch
- [ ] `test_filesystem_store_clear_preserves_metadata`: clear() keeps metadata
- [ ] `test_filesystem_store_destroy_removes_metadata`: destroy() removes everything
- [ ] `test_filesystem_store_factory_with_hasher_algorithm`: factory passes algorithm through