### PR TITLE
ci: enable uv cache in setup-uv steps

### DIFF
--- a/.github/workflows/octocov.yml
+++ b/.github/workflows/octocov.yml
@@ -30,6 +30,8 @@ jobs:
 
       - name: Set up uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        with:
+          enable-cache: true
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -33,6 +33,8 @@ jobs:
 
       - name: Set up uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78
+        with:
+          enable-cache: true
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -31,6 +31,8 @@ jobs:
 
       - name: Set up uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        with:
+          enable-cache: true
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Summary

Add `enable-cache: true` to `astral-sh/setup-uv` steps in CI workflows. This makes the uv dependency cache explicit, avoiding cold-start dependency installs on every run.

## Change scope

- `.github/workflows/octocov.yml`: add `enable-cache: true` to the setup-uv step
- `.github/workflows/python-test.yml`: add `enable-cache: true` to the setup-uv step
- `.github/workflows/pypi-publish.yml`: add `enable-cache: true` to the setup-uv step

## Verification

- `actionlint` passes on all modified workflows
- The `enable-cache: true` flag activates uv's built-in caching mechanism, keyed on `uv.lock` (which is present in the repo)

## Trade-offs

- Cache storage counts against the GitHub Actions cache quota (10 GB by default); negligible for a typical uv cache
- First run after a `uv.lock` change will be a cache miss; subsequent runs benefit