### PR TITLE
chore: constrain dev-shared dependency versions to current major versions

### DIFF
--- a/packages/dev-shared/pyproject.toml
+++ b/packages/dev-shared/pyproject.toml
@@ -8,12 +8,12 @@ classifiers = [
 requires-python = ">=3.10"
 
 dependencies = [
-    "pytest",
-    "pytest-mock",
-    "pytest-cov",
-    "poethepoet",
-    "setuptools-scm",
-    "ruff",
-    "mypy",
-    "ty>=0.0.1a32",
+    "pytest>=9,<10",
+    "pytest-mock>=3,<4",
+    "pytest-cov>=7,<8",
+    "poethepoet>=0.41,<1",
+    "setuptools-scm>=9,<10",
+    "ruff>=0.15,<1",
+    "mypy>=1,<2",
+    "ty>=0.0.1a32,<0.1",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.10"
 
 [options]
-exclude-newer = "2026-04-02T20:14:37.887435Z"
+exclude-newer = "2026-05-30T11:11:32.10868Z"
 exclude-newer-span = "P2D"
 
 [manifest]
@@ -158,14 +158,14 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mypy" },
-    { name = "poethepoet" },
-    { name = "pytest" },
-    { name = "pytest-cov" },
-    { name = "pytest-mock" },
-    { name = "ruff" },
-    { name = "setuptools-scm" },
-    { name = "ty", specifier = ">=0.0.1a32" },
+    { name = "mypy", specifier = ">=1,<2" },
+    { name = "poethepoet", specifier = ">=0.41,<1" },
+    { name = "pytest", specifier = ">=9,<10" },
+    { name = "pytest-cov", specifier = ">=7,<8" },
+    { name = "pytest-mock", specifier = ">=3,<4" },
+    { name = "ruff", specifier = ">=0.15,<1" },
+    { name = "setuptools-scm", specifier = ">=9,<10" },
+    { name = "ty", specifier = ">=0.0.1a32,<0.1" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Add explicit upper bound constraints to `dev-shared` dependencies to prevent silent major version bumps when running `uv sync --upgrade`.

## Problem

Most tools in `packages/dev-shared/pyproject.toml` had no version constraints, allowing Renovate to silently bump to any major version. Tools like `ruff`, `mypy`, and `pytest` introduce breaking changes across major versions (option removals, schema changes, default behavior changes). `ty` was constrained only by a lower alpha bound with no upper limit.

## Changes

- `pytest`: `"pytest"` → `"pytest>=9,<10"`
- `pytest-mock`: `"pytest-mock"` → `"pytest-mock>=3,<4"`
- `pytest-cov`: `"pytest-cov"` → `"pytest-cov>=7,<8"`
- `poethepoet`: `"poethepoet"` → `"poethepoet>=0.41,<1"`
- `setuptools-scm`: `"setuptools-scm"` → `"setuptools-scm>=9,<10"`
- `ruff`: `"ruff"` → `"ruff>=0.15,<1"`
- `mypy`: `"mypy"` → `"mypy>=1,<2"`
- `ty`: `"ty>=0.0.1a32"` → `"ty>=0.0.1a32,<0.1"`

## Effect

- Renovate will still propose major version bumps as explicit PRs rather than auto-applying them
- The lockfile (`uv.lock`) is unchanged in resolved versions; only metadata now reflects the specifiers
- All existing tests pass with the constrained versions
