### PR TITLE
Add coverage threshold to octocov config

### DIFF
--- a/.octocov.yml
+++ b/.octocov.yml
@@ -2,6 +2,7 @@
 coverage:
   paths:
     - "**/coverage.xml"
+  acceptable: current >= 80%
 codeToTestRatio:
   code:
     - "**/*.py"


### PR DESCRIPTION
## Summary

The octocov CI step reports coverage but never fails — there is no
`coverage.acceptable` field in `.octocov.yml`, so any drop in coverage
(even to 0%) passes CI. This applies to the combined coverage across all
packages (`**/coverage.xml`).

This PR adds:

```yaml
coverage:
  acceptable: current >= 80%
```

Current coverage is 95.1%, so the 80% threshold gives headroom for
normal churn while blocking large regressions.

## Test plan

- [ ] CI octocov step passes (current combined coverage ~95.1% >> 80% threshold)
- [ ] Future PRs that drop coverage below 80% will now fail the
      `Report coverage with octocov` step