### PR TITLE
chore: add lefthook to run CI checks locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,34 @@ uv run poe format
 uv run poe check
 ```
 
+## Development
+
+This repository uses [lefthook](https://lefthook.dev/) to run the same checks as CI
+locally, so problems surface before they reach CI.
+
+```sh
+# Install dependencies
+uv sync
+
+# Install the Git hooks (once; requires lefthook on your PATH)
+lefthook install
+```
+
+Once installed, the hooks run automatically:
+
+- **pre-commit**: `uv run poe check`
+- **pre-push**: `uv run poe check` and `uv run poe test`
+
+You can also run the checks manually:
+
+```sh
+uv run poe check
+uv run poe test
+```
+
+CI still runs the full matrix (see `.github/workflows/`); the hooks only bring that
+feedback earlier on your machine.
+
 # LICENSE
 
 BSD 3-Clause License

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,13 @@
+# Clear Git hook environment variables before running checks so nested or sibling
+# repositories are not affected: https://git-scm.com/docs/githooks
+pre-commit:
+  jobs:
+    - name: check
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; uv run poe check
+
+pre-push:
+  jobs:
+    - name: check
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; uv run poe check
+    - name: test
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; uv run poe test


### PR DESCRIPTION
## Summary

- Adds `lefthook.yml` so the same `poe check` and `poe test` commands that run in CI also run locally on pre-commit and pre-push.
- CI (GitHub Actions) is kept completely unchanged — Actions is free for public repos; the hooks only surface feedback earlier on a developer's machine.

## Changes

- **`lefthook.yml`** — new file; defines two hooks:
  - `pre-commit`: runs `uv run poe check`
  - `pre-push`: runs `uv run poe check` and `uv run poe test`
  - Git environment variables are cleared before each job so nested/sibling repositories are not affected.
- **`README.md`** — adds a `## Development` section (inserted before the `# LICENSE` section) explaining how to install and use the hooks.

## Verification

- `uv run poe check` passes locally on `main` before branching.
- `uv run poe test` passes locally on `main` before branching.
- The pre-commit hook fired during `git commit` and passed.
- The pre-push hook (check + test) fired during `git push` and passed.

## Notes

- `lefthook` must be on your `PATH` to use the hooks (`lefthook install` is a one-time setup).
- No CI workflow was modified; `.github/workflows/` is untouched.
