### PR TITLE
Enable SLSA build provenance attestation in PyPI publish workflow

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -23,6 +23,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      attestations: write
     strategy:
       fail-fast: false
       matrix:
@@ -61,3 +62,4 @@ jobs:
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
         with:
           packages-dir: packages/${{ matrix.targets }}/dist
+          attestations: true


### PR DESCRIPTION
## Summary

Enables SLSA build provenance attestation for packages published to PyPI.

## Changes

- Add `attestations: write` permission to the `deploy` job (alongside the existing `id-token: write`)
- Set `attestations: true` on the `pypa/gh-action-pypi-publish` step for the production PyPI publish

With these two changes, `pypa/gh-action-pypi-publish` generates a SLSA provenance attestation for each built distribution and uploads it to PyPI alongside the package. Consumers and auditors can then cryptographically verify that a release on PyPI was produced by this CI workflow.

## Verification

The attestation runs only on full releases (`!github.event.release.prerelease`), matching the existing publish gate. The Test PyPI pre-release path is unaffected.

## Trade-offs

- The `pypa/gh-action-pypi-publish` action's Trusted Publisher (OIDC) path is already active for the production publish step (no `password` field); this PR adds attestation on top of that existing setup.
- Test PyPI attestation is not included here to keep the change minimal; it can be added in a follow-up.
