### PR TITLE
fix: correct HashStore.verify() docstring to reflect actual default action

### DIFF
--- a/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/__init__.py
+++ b/packages/kitsuyui-content_addr/src/kitsuyui/content_addr/hash_store/__init__.py
@@ -85,8 +85,8 @@ class HashStore:
         """Verify the stored item with the given hash value.
         action:
             - 'delete': delete the item if invalid
-            - 'error': raise ValueError if invalid
-            - 'ignore': do nothing if invalid (default)
+            - 'error': raise CorruptedItemError if invalid (default)
+            - 'ignore': do nothing if invalid
         Returns True if the item is valid, False otherwise.
         """
         is_valid = self.is_valid_stored_item(hash_value)

--- a/packages/kitsuyui-content_addr/tests/test_hash_store.py
+++ b/packages/kitsuyui-content_addr/tests/test_hash_store.py
@@ -61,6 +61,16 @@ def test_hash_store() -> None:
     assert not store.stores(hash_value)
 
 
+def test_verify_default_action_raises_on_corrupted_item() -> None:
+    store = HashStore(hasher=SHA256Hasher(), base_store=DictStore())
+    item = RawItem(b"test item")
+    hash_value = store.store(item)
+    store._store_raw(hash_value, RawItem(b"corrupted item"))
+    # Default action is "error", not "ignore" — must raise CorruptedItemError
+    with pytest.raises(CorruptedItemError):
+        store.verify(hash_value)
+
+
 def test_store_if_not_exists() -> None:
     """store_if_not_exists is equivalent to store(conflicts="ignore")."""
     store = HashStore(hasher=SHA256Hasher(), base_store=DictStore())


### PR DESCRIPTION
`HashStore.verify()` has `action: VerifyAction = "error"` as its default
argument, but the docstring listed `'ignore'` as the default with a
`(default)` annotation. Calling `verify()` without an explicit `action`
raises `CorruptedItemError` on invalid items — the opposite of what the
docstring implied.

The docstring also described the `'error'` case as "raise ValueError" when
the implementation actually raises `CorruptedItemError`.

## Changes

- **`hash_store/__init__.py`**: Fix docstring — mark `'error'` as the
  default, remove `(default)` from `'ignore'`, and correct the error
  type from `ValueError` to `CorruptedItemError`.
- **`tests/test_hash_store.py`**: Add `test_verify_default_action_raises_on_corrupted_item`
  to document and enforce the default behaviour.

## Verification

`uv run poe test` — all tests pass.
`uv run poe check` — all checks pass (pre-existing unrelated diagnostic in
`kitsuyui-animal` unchanged).
